### PR TITLE
Style main popup view

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,5 +1,6 @@
 html,
 body {
+    background-color: #fff;
     font-family: sans;
     font-size: 14px;
     margin: 0;
@@ -11,6 +12,6 @@ body {
     border-radius: 4px;
     color: #fff;
     font-size: 12px;
-    margin: 0 4px;
-    padding: 2px 4px;
+    margin: 0 6px;
+    padding: 1px 4px;
 }

--- a/src/popup/interface.js
+++ b/src/popup/interface.js
@@ -115,7 +115,7 @@ function view(ctl, params) {
                                           result.recent.count +
                                           " time" +
                                           (result.recent.count > 1 ? "s" : "") +
-                                          ", last " +
+                                          ", last used " +
                                           Moment(new Date(result.recent.when)).fromNow()
                                   })
                                 : null

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -24,7 +24,7 @@ body {
     box-sizing: border-box;
     display: flex;
     flex-shrink: 0;
-    min-height: 29px;
+    min-height: 22px;
     width: 100%;
 }
 
@@ -39,11 +39,13 @@ body {
 .part.error {
     color: #f00;
     white-space: normal;
+    padding: 7px;
 }
 
 .part.notice {
     color: #090;
     white-space: normal;
+    padding: 7px;
 }
 
 .part.search {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -117,6 +117,7 @@ body {
     background-size: contain;
     margin-left: 4px;
     width: 10px;
+    margin-top: 2px;
 }
 
 .part.login > .action {
@@ -142,6 +143,7 @@ body {
 
 .part.login > .action.launch {
     background-image: url("icon-launch.svg");
+    background-position-y: 5.5px;
 }
 
 .part.login em {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -5,6 +5,10 @@ body {
     white-space: nowrap;
 }
 
+html::-webkit-scrollbar {
+    display: none;
+}
+
 body {
     display: flex;
     flex-direction: column;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -25,7 +25,6 @@ body {
     display: flex;
     flex-shrink: 0;
     min-height: 29px;
-    padding: 6px;
     width: 100%;
 }
 
@@ -48,15 +47,16 @@ body {
 }
 
 .part.search {
-    padding-right: 28px;
+    padding: 6px 28px 6px 6px;
     background-image: url("icon-search.svg");
     background-position: top 6px right 6px;
     background-repeat: no-repeat;
     background-size: 18px;
+    background-color: #f7f7f7;
 }
 
 .part.search:focus-within {
-    background-color: #eef;
+    background-color: #fff;
 }
 
 .part.search > .hint {
@@ -68,8 +68,9 @@ body {
     background-image: url("icon-bs-delete.svg");
     background-repeat: no-repeat;
     background-size: contain;
+    cursor: pointer;
     height: 12px;
-    margin: 1px 0 1px 4px;
+    margin: 3px 0 3px 4px;
     width: 16px;
 }
 
@@ -82,21 +83,28 @@ body {
 
 .part.login {
     display: flex;
+    cursor: pointer;
 }
 
-.part.login:first-child {
-    background-color: #efe;
+.logins:not(:hover):not(:focus-within) .part.login:first-child > .name {
+    background-color: #f7f7f7;
 }
 
 .part.login:hover,
 .part.login:focus {
-    background-color: #eee;
     outline: none;
+}
+
+.part.login > .name:hover,
+.part.login > .action:hover,
+.part.login:focus > .name {
+    background-color: #eee;
 }
 
 .part.login > .name {
     display: flex;
     width: 100%;
+    padding: 6px;
 }
 
 .part.login > .name > .recent {
@@ -104,16 +112,15 @@ body {
     background-repeat: no-repeat;
     background-size: contain;
     margin-left: 4px;
-    width: 16px;
+    width: 10px;
 }
 
 .part.login > .action {
-    background-position: right 3px top 0;
+    background-position: right 6px top 6px;
     background-repeat: no-repeat;
-    background-size: 20px;
-    filter: drop-shadow(2px 2px 1px #666) invert(18%);
-    margin: -2px 0;
+    background-size: 19px;
     width: 30px;
+    padding: 6px;
 }
 
 .past.login > .action:hover {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -16,7 +16,7 @@ body {
     flex-direction: column;
     overflow-y: auto;
     height: inherit;
-    max-height: 203px; /* 7 x 29px login part*/
+    max-height: 217px; /* 7 x 31px login part*/
 }
 
 .part {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -5,7 +5,8 @@ body {
     white-space: nowrap;
 }
 
-html::-webkit-scrollbar {
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
     display: none;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -87,6 +87,7 @@ body {
 .part.login {
     display: flex;
     cursor: pointer;
+    align-items: center;
 }
 
 .logins:not(:hover):not(:focus-within) .part.login:first-child > .name {
@@ -119,10 +120,11 @@ body {
 }
 
 .part.login > .action {
-    background-position: right 6px top 6px;
+    background-position: center;
     background-repeat: no-repeat;
     background-size: 19px;
     width: 30px;
+    height: 19px;
     padding: 6px;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -88,6 +88,7 @@ body {
     display: flex;
     cursor: pointer;
     align-items: center;
+    height: 31px;
 }
 
 .logins:not(:hover):not(:focus-within) .part.login:first-child > .name {
@@ -108,6 +109,7 @@ body {
 .part.login > .name {
     display: flex;
     width: 100%;
+    height: 19px;
     padding: 6px;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -63,6 +63,8 @@ body {
 .part.search > .hint {
     background-color: #66c;
     display: flex;
+    align-items: center;
+    line-height: 19px;
 }
 
 .part.search > .hint > .remove-hint {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -24,7 +24,6 @@ body {
     box-sizing: border-box;
     display: flex;
     flex-shrink: 0;
-    min-height: 22px;
     width: 100%;
 }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1177900/39084391-7da578e2-4575-11e8-90dd-2e33854a8bdd.png)

After:

![image](https://user-images.githubusercontent.com/1177900/39084398-90251cfc-4575-11e8-8e74-59d811e2d0c7.png)

-----

Main changes:

- Less colors:
    - Search box is white (not... violet?)
    - Inactive search box and the first entry is light-gray
    - focused / hovered entry is gray
    - visually distinguish focus / hover of entries (fill action) and buttons (copy / navigate actions)
- The first entry is only highlighted if no other entry is focused or hovered.
- Alignments, paddings
- No shadows on buttons, with background on hover they look like buttons anyway (and also shadow conflicted with background color 😉)
