### PR TITLE
Support login forms in iframe

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ BROWSERIFY := node_modules/.bin/browserify
 PRETTIER := node_modules/.bin/prettier
 
 CLEAN_FILES := js
-PRETTIER_FILES := $(wildcard *.js popup/*.js *.css popup/*.css)
+PRETTIER_FILES := $(wildcard *.js *.json popup/*.js *.css popup/*.css)
 
 .PHONY: all
 all: deps prettier js/background.dist.js js/popup.dist.js js/inject.dist.js

--- a/src/background.js
+++ b/src/background.js
@@ -240,7 +240,10 @@ async function handleMessage(settings, message, sendResponse) {
         case "fill":
             try {
                 var tab = (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
-                await chrome.tabs.executeScript(tab.id, { file: "js/inject.dist.js" });
+                await chrome.tabs.executeScript(tab.id, {
+                    allFrames: true,
+                    file: "js/inject.dist.js"
+                });
                 // check login fields
                 if (message.login.fields.login === null) {
                     throw new Error("No login is available");
@@ -254,6 +257,7 @@ async function handleMessage(settings, message, sendResponse) {
                 });
                 // fill form via injected script
                 await chrome.tabs.executeScript(tab.id, {
+                    allFrames: true,
                     code: `window.browserpass.fillLogin(${fillFields});`
                 });
                 sendResponse({ status: "ok" });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,19 +1,15 @@
 {
-    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvlVUvevBvdeIFpvK5Xjcbd/cV8AsMNLg0Y7BmUetSTagjts949Tp12mNmWmIEEaE9Zwmfjl1ownWiclGhsoPSf6x7nP/i0j8yROv6TYibXLhZet9y4vnUMgtCIkb3O5RnuOl0Y+V3XUADwxotmgT1laPUThymJoYnWPv+lwDkYiEopX2Aq2amzRj8aMogNBUbAIkCMxfa9WK3Vm0QTAUdV4ii9WqzbgjHVruQpiFVq99W2U9ddsWNZjOG/36sFREuHw+reulQgblp9FZdaN1Q9X5cGcT5bncQIRB6K3wZYa805gFENc93Wslmzu6aUSEKqqPymlI5ikedaPlXPmlqwIDAQAB",
+    "key":
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvlVUvevBvdeIFpvK5Xjcbd/cV8AsMNLg0Y7BmUetSTagjts949Tp12mNmWmIEEaE9Zwmfjl1ownWiclGhsoPSf6x7nP/i0j8yROv6TYibXLhZet9y4vnUMgtCIkb3O5RnuOl0Y+V3XUADwxotmgT1laPUThymJoYnWPv+lwDkYiEopX2Aq2amzRj8aMogNBUbAIkCMxfa9WK3Vm0QTAUdV4ii9WqzbgjHVruQpiFVq99W2U9ddsWNZjOG/36sFREuHw+reulQgblp9FZdaN1Q9X5cGcT5bncQIRB6K3wZYa805gFENc93Wslmzu6aUSEKqqPymlI5ikedaPlXPmlqwIDAQAB",
     "manifest_version": 2,
     "name": "Browserpass CE",
     "description": "Browser extension for zx2c4's pass (password manager) - Community Edition.",
     "version": "3.0.0",
-    "author": [
-        "Maxim Baz <browserpass@maximbaz.com>",
-        "Steve Gilberd <steve@erayd.net>"
-    ],
+    "author": ["Maxim Baz <browserpass@maximbaz.com>", "Steve Gilberd <steve@erayd.net>"],
     "homepage_url": "https://github.com/browserpass/browserpass-extension",
     "background": {
         "persistent": true,
-        "scripts": [
-            "js/background.dist.js"
-        ]
+        "scripts": ["js/background.dist.js"]
     },
     "icons": {
         "128": "icon-lock.png"
@@ -22,17 +18,8 @@
         "default_icon": "icon-lock.png",
         "default_popup": "popup/popup.html"
     },
-    "permissions": [
-        "activeTab",
-        "nativeMessaging",
-        "notifications"
-    ],
-    "optional_permissions": [
-        "webRequest",
-        "webRequestBlocking",
-        "http://*/*",
-        "https://*/*"
-    ],
+    "permissions": ["activeTab", "nativeMessaging", "notifications", "http://*/*", "https://*/*"],
+    "optional_permissions": ["webRequest", "webRequestBlocking"],
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -179,8 +179,7 @@ async function withLogin(action) {
                 break;
             case "launch":
                 var havePermission = await chrome.permissions.request({
-                    permissions: ["webRequest", "webRequestBlocking"],
-                    origins: ["http://*/*", "https://*/*"]
+                    permissions: ["webRequest", "webRequestBlocking"]
                 });
                 if (!havePermission) {
                     throw new Error("Browserpass requires additional permissions to proceed");


### PR DESCRIPTION
We have to inject the script in all frames, because the login form is not necessarily in the top frame. 

For example, we have a "login with national ID" provider in Denmark, and all banks and government sites show their login form in an iframe.

Funny thing, the request for optional permissions is now completely silent, because as per MDN:

> Of this set, the following permissions are granted silently, without a user prompt: activeTab, cookies, idle, webRequest, webRequestBlocking.