### PR TITLE
Show browser notifications on installation and for major updates

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,8 @@
     },
     "permissions": [
         "activeTab",
-        "nativeMessaging"
+        "nativeMessaging",
+        "notifications"
     ],
     "optional_permissions": [
         "webRequest",


### PR DESCRIPTION
Update notifications are intended to be used very rarely, e.g. on breaking changes. But it's a good place to notify the users about v3.0.0.

The point of `changelog` variable being an object is the following, suppose we have two entries:

```
3000000: "update host app",
3001000: "do something else"
```

People who update from v2.x.x to v3.1.0 will see two notifications, "update host app" and "do something else". People who update from v3.0.0 to v3.1.0 will see only one notification, "do something else".