### PR TITLE
Fill into iframes on primary frame failure

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -255,22 +255,19 @@ async function handleMessage(settings, message, sendResponse) {
                 var fillFields = JSON.stringify({
                     login: message.login.fields.login,
                     secret: message.login.fields.secret,
-                    origin: tabOrigin
+                    origin: tabOrigin,
+                    autoSubmit: message.login.autoSubmit ? ["login", "secret"] : []
                 });
                 // fill form via injected script
                 var filledFields = await chrome.tabs.executeScript(tab.id, {
-                    code: `window.browserpass.fillLogin(${fillFields}, ${
-                        message.login.autoSubmit ? "true" : "false"
-                    });`
+                    code: `window.browserpass.fillLogin(${fillFields});`
                 });
                 // try again using all available frames if we couldn't fill a password field
                 if (!filledFields[0].includes("secret")) {
                     filledFields = filledFields.concat(
                         await chrome.tabs.executeScript(tab.id, {
                             allFrames: true,
-                            code: `window.browserpass.fillLogin(${fillFields}, ${
-                                message.login.autoSubmit ? "true" : "false"
-                            });`
+                            code: `window.browserpass.fillLogin(${fillFields});`
                         })
                     );
                 }

--- a/src/background.js
+++ b/src/background.js
@@ -345,10 +345,8 @@ async function handleMessage(settings, message, sendResponse) {
 
                 // dispatch initial fill request
                 var filledFields = await fillFields(targetTab, message.login, ["login", "secret"]);
-                if (!filledFields.length) {
-                    throw new Error("Unable to fill credentials");
-                }
 
+                // no need to check filledFields, because fillFields() already throws an error if empty
                 sendResponse({ status: "ok", filledFields: filledFields });
             } catch (e) {
                 try {

--- a/src/background.js
+++ b/src/background.js
@@ -88,6 +88,7 @@ async function fillFields(tab, login, fields) {
     var fillRequest = {
         allowForeign: false,
         autoSubmit: login.autoSubmit ? autoSubmitFields : [],
+        submitTarget: login.submitTarget,
         origin: new URL(tab.url).origin,
         login: login,
         fields: fields
@@ -418,6 +419,7 @@ async function parseFields(settings, login) {
     // parse lines
     login.fields = {
         autoSubmit: ["auto-submit", "autosubmit"],
+        submitTarget: ["submit-target", "submittarget"],
         secret: ["secret", "password", "pass"],
         login: ["login", "username", "user", "email"],
         url: ["url", "uri", "website", "site", "link", "launch"]
@@ -459,7 +461,7 @@ async function parseFields(settings, login) {
     }
 
     // move browserpass settings out of fields
-    for (var field of ["autoSubmit"]) {
+    for (var field of ["autoSubmit", "submitTarget"]) {
         login[field] = login.fields[field];
         delete login.fields[field];
     }

--- a/src/background.js
+++ b/src/background.js
@@ -249,7 +249,7 @@ async function handleMessage(settings, message, sendResponse) {
                 var fields = await fillFields(targetTab, message.login, remainingFields);
                 filledFields = fields;
                 remainingFields = remainingFields.filter(field => !filledFields.includes(field));
-                if (remainingFields.length) {
+                if (remainingFields.length && message.login.autoSubmit) {
                     // use tab event handler for multiple-submit autofill
                     chrome.tabs.onUpdated.addListener(async function listener(tabID, info) {
                         if (tabID !== targetTab.id || info.status !== "complete") {

--- a/src/background.js
+++ b/src/background.js
@@ -69,18 +69,18 @@ function copyToClipboard(text) {
  * @return array List of filled fields
  */
 async function fillFields(tab, login, fields) {
-    // inject script
-    await chrome.tabs.executeScript(tab.id, {
-        allFrames: true,
-        file: "js/inject.dist.js"
-    });
-
     // check that required fields are present
     for (var field of fields) {
         if (login.fields[field] === null) {
             throw new Error(`Required field is missing: ${field}`);
         }
     }
+
+    // inject script
+    await chrome.tabs.executeScript(tab.id, {
+        allFrames: true,
+        file: "js/inject.dist.js"
+    });
 
     // build fill request
     var fillRequest = {

--- a/src/background.js
+++ b/src/background.js
@@ -266,15 +266,16 @@ async function handleMessage(settings, message, sendResponse) {
                             remainingFields = remainingFields.filter(
                                 field => !filledFields.includes(field)
                             );
+                            if (!remainingFields.length) {
+                                chrome.tabs.onUpdated.removeListener(listener);
+                                sendResponse({ status: "ok", filledFields: filledFields });
+                            }
                         } catch (e) {
                             chrome.tabs.onUpdated.removeListener(listener);
                             sendResponse({
                                 status: "error",
                                 message: `Multi-stage autofill failed: ${e.toString()}`
                             });
-                        }
-                        if (!remainingFields.length) {
-                            sendResponse({ status: "ok", filledFields: filledFields });
                         }
                     });
                 } else {

--- a/src/background.js
+++ b/src/background.js
@@ -88,7 +88,6 @@ async function fillFields(tab, login, fields) {
     var fillRequest = {
         allowForeign: false,
         autoSubmit: login.autoSubmit ? autoSubmitFields : [],
-        submitTarget: login.submitTarget,
         origin: new URL(tab.url).origin,
         login: login,
         fields: fields
@@ -421,7 +420,6 @@ async function parseFields(settings, login) {
     // parse lines
     login.fields = {
         autoSubmit: ["auto-submit", "autosubmit"],
-        submitTarget: ["submit-target", "submittarget"],
         secret: ["secret", "password", "pass"],
         login: ["login", "username", "user", "email"],
         url: ["url", "uri", "website", "site", "link", "launch"]
@@ -463,7 +461,7 @@ async function parseFields(settings, login) {
     }
 
     // move browserpass settings out of fields
-    for (var field of ["autoSubmit", "submitTarget"]) {
+    for (var field of ["autoSubmit"]) {
         login[field] = login.fields[field];
         delete login.fields[field];
     }

--- a/src/background.js
+++ b/src/background.js
@@ -274,6 +274,7 @@ async function handleMessage(settings, message, sendResponse) {
                         })
                     );
                 }
+                // simplify the list of filled fields
                 filledFields = filledFields
                     .reduce((fields, addFields) => fields.concat(addFields), [])
                     .reduce(function(fields, field) {

--- a/src/background.js
+++ b/src/background.js
@@ -124,8 +124,6 @@ async function fillFields(tab, login, fields) {
 
     // build fill request
     var fillRequest = {
-        allowForeign: false,
-        allowNoSecret: false,
         origin: new URL(tab.url).origin,
         login: login,
         fields: fields

--- a/src/background.js
+++ b/src/background.js
@@ -351,10 +351,17 @@ async function handleMessage(settings, message, sendResponse) {
 
                 sendResponse({ status: "ok", filledFields: filledFields });
             } catch (e) {
-                sendResponse({
-                    status: "error",
-                    message: "Unable to fill credentials: " + e.toString()
-                });
+                try {
+                    sendResponse({
+                        status: "error",
+                        message: e.toString()
+                    });
+                } catch (e) {
+                    // TODO An error here is typically a closed message port, due to a popup taking focus
+                    // away from the extension menu and the menu closing as a result. Need to investigate
+                    // whether triggering the extension menu from the background script is possible.
+                    console.log(e);
+                }
             }
             break;
         default:

--- a/src/inject.js
+++ b/src/inject.js
@@ -83,30 +83,34 @@
         // get the login form
         var loginForm = form();
 
-        // ensure the origin is the same, or ask the user for permissions to continue
-        if (window.location.origin !== request.origin) {
-            var message =
-                "You have requested to fill login credentials into an embedded document from a " +
-                "different origin than the main document in this tab. Do you wish to proceed?\n\n" +
-                `Tab origin: ${request.origin}\n` +
-                `Embedded origin: ${window.location.origin}`;
-            if (!confirm(message)) {
-                return filledFields;
-            }
-        }
-
-        // fill available fields
+        // fill login field
         if (
             request.fields.includes("login") &&
             update(USERNAME_FIELDS, request.login.fields.login, loginForm)
         ) {
             filledFields.push("login");
         }
-        if (
-            request.fields.includes("secret") &&
-            update(PASSWORD_FIELDS, request.login.fields.secret, loginForm)
-        ) {
-            filledFields.push("secret");
+
+        // fill secret field
+        if (request.fields.includes("secret") && find(PASSWORD_FIELDS, loginForm)) {
+            // ensure the origin is the same, or ask the user for permissions to continue
+            if (window.location.origin !== request.origin) {
+                if (!request.allowForeign) {
+                    return filledFields;
+                }
+                var message =
+                    "You have requested to fill sensitive credentials into an embedded document from a " +
+                    "different origin than the main document in this tab. Do you wish to proceed?\n\n" +
+                    `Tab origin: ${request.origin}\n` +
+                    `Embedded origin: ${window.location.origin}`;
+                if (confirm(message)) {
+                    update(PASSWORD_FIELDS, request.login.fields.secret, loginForm);
+                    filledFields.push("secret");
+                }
+            } else {
+                update(PASSWORD_FIELDS, request.login.fields.secret, loginForm);
+                filledFields.push("secret");
+            }
         }
 
         // check whether we filled something that should be auto-submitted

--- a/src/inject.js
+++ b/src/inject.js
@@ -78,10 +78,12 @@
      * @return void
      */
     function fillLogin(login, autoSubmit = false) {
+        var filledFields = [];
+
         // get the login form
         var loginForm = form();
         if (!loginForm) {
-            return false;
+            return filledFields;
         }
 
         // ensure the origin is the same, or ask the user for permissions to continue
@@ -92,12 +94,11 @@
                 `Tab origin: ${login.origin}\n` +
                 `Embedded origin: ${window.location.origin}`;
             if (!confirm(message)) {
-                return false;
+                return filledFields;
             }
         }
 
         // fill available fields
-        var filledFields = [];
         if (update(USERNAME_FIELDS, login.login, loginForm)) {
             filledFields.push("login");
         }

--- a/src/inject.js
+++ b/src/inject.js
@@ -128,7 +128,9 @@
         } else {
             window.requestAnimationFrame(function() {
                 // Try to submit the form, or focus on the submit button (based on user settings)
-                var submit = find(SUBMIT_FIELDS, loginForm);
+                var submit = request.submitTarget
+                    ? document.querySelector(request.submitTarget)
+                    : find(SUBMIT_FIELDS, loginForm);
                 if (submit) {
                     if (autoSubmit) {
                         submit.click();

--- a/src/inject.js
+++ b/src/inject.js
@@ -82,9 +82,6 @@
 
         // get the login form
         var loginForm = form();
-        if (!loginForm) {
-            return filledFields;
-        }
 
         // ensure the origin is the same, or ask the user for permissions to continue
         if (window.location.origin !== request.origin) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -78,10 +78,37 @@
      * @return void
      */
     function fillLogin(login, autoSubmit = false) {
-        var loginForm = form();
+        // ensure the origin is the same, or ask the user for permissions to continue
+        if (window.location.origin !== login.origin) {
+            var message =
+                "You have requested to fill login credentials into an embedded document from a " +
+                "different origin than the main document in this tab. Do you wish to proceed?\n\n" +
+                `Tab origin: ${login.origin}\n` +
+                `Embedded origin: ${window.location.origin}`;
+            if (!confirm(message)) {
+                return false;
+            }
+        }
 
-        update(USERNAME_FIELDS, login.login, loginForm);
-        update(PASSWORD_FIELDS, login.secret, loginForm);
+        // get the login form
+        var loginForm = form();
+        if (!loginForm) {
+            return false;
+        }
+
+        // fill available fields
+        var filledCount = 0;
+        if (update(USERNAME_FIELDS, login.login, loginForm)) {
+            filledCount++;
+        }
+        if (update(PASSWORD_FIELDS, login.secret, loginForm)) {
+            filledCount++;
+        }
+
+        // no fields filled, so return failure state
+        if (!filledCount) {
+            return false;
+        }
 
         var password_inputs = queryAllVisible(document, PASSWORD_FIELDS, loginForm);
         if (password_inputs.length > 1) {
@@ -115,6 +142,9 @@
                 }
             });
         }
+
+        // finished filling things successfully
+        return true;
     }
 
     /**

--- a/src/inject.js
+++ b/src/inject.js
@@ -109,8 +109,10 @@
         }
 
         // fill secret field
-        if (find(PASSWORD_FIELDS, loginForm)) {
-            update(PASSWORD_FIELDS, request.login.fields.secret, loginForm);
+        if (
+            request.fields.includes("secret") &&
+            update(PASSWORD_FIELDS, request.login.fields.secret, loginForm)
+        ) {
             filledFields.push("secret");
         }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -113,14 +113,6 @@
             }
         }
 
-        // check whether we filled something that should be auto-submitted
-        for (var field of request.autoSubmit) {
-            if (filledFields.includes(field)) {
-                autoSubmit = true;
-                break;
-            }
-        }
-
         var password_inputs = queryAllVisible(document, PASSWORD_FIELDS, loginForm);
         if (password_inputs.length > 1) {
             // There is likely a field asking for OTP code, so do not submit form just yet

--- a/src/inject.js
+++ b/src/inject.js
@@ -73,10 +73,10 @@
      *
      * @since 3.0.0
      *
-     * @param object login      Login fields
+     * @param object request Form fill request
      * @return void
      */
-    function fillLogin(login) {
+    function fillLogin(request) {
         var autoSubmit = false;
         var filledFields = [];
 
@@ -87,11 +87,11 @@
         }
 
         // ensure the origin is the same, or ask the user for permissions to continue
-        if (window.location.origin !== login.origin) {
+        if (window.location.origin !== request.origin) {
             var message =
                 "You have requested to fill login credentials into an embedded document from a " +
                 "different origin than the main document in this tab. Do you wish to proceed?\n\n" +
-                `Tab origin: ${login.origin}\n` +
+                `Tab origin: ${request.origin}\n` +
                 `Embedded origin: ${window.location.origin}`;
             if (!confirm(message)) {
                 return filledFields;
@@ -99,15 +99,21 @@
         }
 
         // fill available fields
-        if (update(USERNAME_FIELDS, login.login, loginForm)) {
+        if (
+            request.fields.includes("login") &&
+            update(USERNAME_FIELDS, request.login.fields.login, loginForm)
+        ) {
             filledFields.push("login");
         }
-        if (update(PASSWORD_FIELDS, login.secret, loginForm)) {
+        if (
+            request.fields.includes("secret") &&
+            update(PASSWORD_FIELDS, request.login.fields.secret, loginForm)
+        ) {
             filledFields.push("secret");
         }
 
         // check whether we filled something that should be auto-submitted
-        for (var field of login.autoSubmit) {
+        for (var field of request.autoSubmit) {
             if (filledFields.includes(field)) {
                 autoSubmit = true;
                 break;

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,4 +1,7 @@
 (function() {
+    const SUBMIT_SPECIAL_CASES = {
+        "accounts.google.com": "[id $= 'Next']"
+    };
     const FORM_MARKERS = ["login", "log-in", "log_in", "signin", "sign-in", "sign_in"];
     const USERNAME_FIELDS = {
         selectors: [
@@ -79,6 +82,14 @@
     function fillLogin(request) {
         var autoSubmit = false;
         var filledFields = [];
+
+        // set special-case submit target
+        if (
+            request.submitTarget === null &&
+            SUBMIT_SPECIAL_CASES.hasOwnProperty(window.location.host)
+        ) {
+            request.submitTarget = SUBMIT_SPECIAL_CASES[window.location.host];
+        }
 
         // get the login form
         var loginForm = form();

--- a/src/inject.js
+++ b/src/inject.js
@@ -74,10 +74,10 @@
      * @since 3.0.0
      *
      * @param object login      Login fields
-     * @param bool   autoSubmit Whether to autosubmit the login form
      * @return void
      */
-    function fillLogin(login, autoSubmit = false) {
+    function fillLogin(login) {
+        var autoSubmit = false;
         var filledFields = [];
 
         // get the login form
@@ -104,6 +104,14 @@
         }
         if (update(PASSWORD_FIELDS, login.secret, loginForm)) {
             filledFields.push("secret");
+        }
+
+        // check whether we filled something that should be auto-submitted
+        for (var field of login.autoSubmit) {
+            if (filledFields.includes(field)) {
+                autoSubmit = true;
+                break;
+            }
         }
 
         var password_inputs = queryAllVisible(document, PASSWORD_FIELDS, loginForm);

--- a/src/inject.js
+++ b/src/inject.js
@@ -1,7 +1,4 @@
 (function() {
-    const SUBMIT_SPECIAL_CASES = {
-        "accounts.google.com": "[id $= 'Next']"
-    };
     const FORM_MARKERS = ["login", "log-in", "log_in", "signin", "sign-in", "sign_in"];
     const USERNAME_FIELDS = {
         selectors: [
@@ -83,14 +80,6 @@
         var autoSubmit = false;
         var filledFields = [];
 
-        // set special-case submit target
-        if (
-            request.submitTarget === null &&
-            SUBMIT_SPECIAL_CASES.hasOwnProperty(window.location.host)
-        ) {
-            request.submitTarget = SUBMIT_SPECIAL_CASES[window.location.host];
-        }
-
         // get the login form
         var loginForm = form();
 
@@ -139,24 +128,7 @@
         } else {
             window.requestAnimationFrame(function() {
                 // try to locate the submit button
-                var submit = request.submitTarget
-                    ? document.querySelector(request.submitTarget)
-                    : find(SUBMIT_FIELDS, loginForm);
-                var submit = null;
-                if (request.submitTarget) {
-                    if (loginForm) {
-                        for (var el = loginForm; el.parentNode; el = el.parentNode) {
-                            if ((submit = el.querySelector(request.submitTarget))) {
-                                break;
-                            }
-                        }
-                    } else {
-                        submit = document.querySelector(request.submitTarget);
-                    }
-                }
-                if (!submit) {
-                    submit = find(SUBMIT_FIELDS, loginForm);
-                }
+                var submit = find(SUBMIT_FIELDS, loginForm);
 
                 // Try to submit the form, or focus on the submit button (based on user settings)
                 if (submit) {

--- a/src/inject.js
+++ b/src/inject.js
@@ -78,6 +78,12 @@
      * @return void
      */
     function fillLogin(login, autoSubmit = false) {
+        // get the login form
+        var loginForm = form();
+        if (!loginForm) {
+            return false;
+        }
+
         // ensure the origin is the same, or ask the user for permissions to continue
         if (window.location.origin !== login.origin) {
             var message =
@@ -88,12 +94,6 @@
             if (!confirm(message)) {
                 return false;
             }
-        }
-
-        // get the login form
-        var loginForm = form();
-        if (!loginForm) {
-            return false;
         }
 
         // fill available fields

--- a/src/inject.js
+++ b/src/inject.js
@@ -138,10 +138,27 @@
             password_inputs[1].select();
         } else {
             window.requestAnimationFrame(function() {
-                // Try to submit the form, or focus on the submit button (based on user settings)
+                // try to locate the submit button
                 var submit = request.submitTarget
                     ? document.querySelector(request.submitTarget)
                     : find(SUBMIT_FIELDS, loginForm);
+                var submit = null;
+                if (request.submitTarget) {
+                    if (loginForm) {
+                        for (var el = loginForm; el.parentNode; el = el.parentNode) {
+                            if ((submit = el.querySelector(request.submitTarget))) {
+                                break;
+                            }
+                        }
+                    } else {
+                        submit = document.querySelector(request.submitTarget);
+                    }
+                }
+                if (!submit) {
+                    submit = find(SUBMIT_FIELDS, loginForm);
+                }
+
+                // Try to submit the form, or focus on the submit button (based on user settings)
                 if (submit) {
                     if (autoSubmit) {
                         submit.click();

--- a/src/inject.js
+++ b/src/inject.js
@@ -97,17 +97,12 @@
         }
 
         // fill available fields
-        var filledCount = 0;
+        var filledFields = [];
         if (update(USERNAME_FIELDS, login.login, loginForm)) {
-            filledCount++;
+            filledFields.push("login");
         }
         if (update(PASSWORD_FIELDS, login.secret, loginForm)) {
-            filledCount++;
-        }
-
-        // no fields filled, so return failure state
-        if (!filledCount) {
-            return false;
+            filledFields.push("secret");
         }
 
         var password_inputs = queryAllVisible(document, PASSWORD_FIELDS, loginForm);
@@ -144,7 +139,7 @@
         }
 
         // finished filling things successfully
-        return true;
+        return filledFields;
     }
 
     /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,9 +25,7 @@
     "permissions": [
         "activeTab",
         "nativeMessaging",
-        "notifications"
-    ],
-    "optional_permissions": [
+        "notifications",
         "webRequest",
         "webRequestBlocking",
         "http://*/*",

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -211,7 +211,7 @@ async function withLogin(action) {
                 case "copyUsername":
                     saveRecent(this.settings, this.login);
             }
-            setInterval(() => window.close(), action == "fill" ? 1000 : 0);
+            window.close();
         }
     } catch (e) {
         handleError(e);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -178,13 +178,6 @@ async function withLogin(action) {
                 handleError("Filling login details...", "notice");
                 break;
             case "launch":
-                var havePermission = await chrome.permissions.request({
-                    permissions: ["webRequest", "webRequestBlocking"],
-                    origins: ["http://*/*", "https://*/*"]
-                });
-                if (!havePermission) {
-                    throw new Error("Browserpass requires additional permissions to proceed");
-                }
                 handleError("Launching URL...", "notice");
                 break;
             case "copyPassword":

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -200,13 +200,8 @@ async function withLogin(action) {
             throw new Error(response.message);
         } else {
             switch (action) {
-                case "fill":
-                    // advise the user which fields were filled & close the popup
-                    handleError(
-                        `Filled fields: ${response.filledFields.sort().join(", ")}`,
-                        "notice"
-                    );
                 // fall through to update recent
+                case "fill":
                 case "copyPassword":
                 case "copyUsername":
                     saveRecent(this.settings, this.login);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -206,7 +206,7 @@ async function withLogin(action) {
                     saveRecent(this.settings, this.login);
             }
             // advise the user which fields were filled & close the popup
-            handleError(`Filled fields: ${response.filledFields.join(", ")}`, "notice");
+            handleError(`Filled fields: ${response.filledFields.sort().join(", ")}`, "notice");
             setInterval(() => window.close(), 1000);
         }
     } catch (e) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -201,13 +201,17 @@ async function withLogin(action) {
         } else {
             switch (action) {
                 case "fill":
+                    // advise the user which fields were filled & close the popup
+                    handleError(
+                        `Filled fields: ${response.filledFields.sort().join(", ")}`,
+                        "notice"
+                    );
+                // fall through to update recent
                 case "copyPassword":
                 case "copyUsername":
                     saveRecent(this.settings, this.login);
             }
-            // advise the user which fields were filled & close the popup
-            handleError(`Filled fields: ${response.filledFields.sort().join(", ")}`, "notice");
-            setInterval(() => window.close(), 1000);
+            setInterval(() => window.close(), action == "fill" ? 1000 : 0);
         }
     } catch (e) {
         handleError(e);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -205,7 +205,9 @@ async function withLogin(action) {
                 case "copyUsername":
                     saveRecent(this.settings, this.login);
             }
-            window.close();
+            // advise the user which fields were filled & close the popup
+            handleError(`Filled fields: ${response.filledFields.join(", ")}`, "notice");
+            setInterval(() => window.close(), 1000);
         }
     } catch (e) {
         handleError(e);


### PR DESCRIPTION
## What
 * If unable to fill password in primary frame, re-attempt on all frames
 * Request all permissions at install time, instead of on-demand
 * Prompt the user on foreign origin fill requests

## Why
 * Because filling all frames should not be the default, as it can lead to credental leakage in cases where there is a malicious frame on the same page as a login form (e.g. via an ad).
 * Prompting for an all-sites permission only during some autofills is confusing to the user, and `activeTab` doesn't allow access to other frames (see [here](https://bugs.chromium.org/p/chromium/issues/detail?id=452944)).
 * Autofilling into e.g. an adserver iframe is undesirable, and should be avoided.