### PR TITLE
Include specificity in popup ordering algorithm

### DIFF
--- a/src/popup/interface.js
+++ b/src/popup/interface.js
@@ -154,8 +154,8 @@ function search(s) {
         );
         candidates = recent.concat(remainingInCurrentDomain);
     }
-    candidates.sort(function(a, b) {
-        // sort most recent first
+    candidates.sort((a, b) => {
+        // show most recent first
         if (a === mostRecent) {
             return -1;
         }
@@ -163,10 +163,19 @@ function search(s) {
             return 1;
         }
 
-        // sort by count
+        // sort by frequency
         var countDiff = b.recent.count - a.recent.count;
         if (countDiff) {
             return countDiff;
+        }
+
+        // sort by specificity, only if filtering for one domain
+        if (this.currentDomainOnly) {
+            var domainLevelsDiff =
+                (b.login.match(/\./g) || []).length - (a.login.match(/\./g) || []).length;
+            if (domainLevelsDiff) {
+                return domainLevelsDiff;
+            }
         }
 
         // sort alphabetically


### PR DESCRIPTION
When we are showing results for a single domain, it makes sense to consider specificity and show results for subdomains on top.

For example, when you open `https://aur.archlinux.org` for the very first time, a popup should show `aur.archlinux.org` above `archlinux.org`, not below.

I'm intentionally not including specificity in consideration when the popup is *not* filtered for a single domain, because the order doesn't look self-explanatory at all (and also for performance reasons).

It was also highly requested in https://github.com/browserpass/browserpass/issues/264