### PR TITLE
Show badge with the number of matching entries

### DIFF
--- a/src/manifest-chromium.json
+++ b/src/manifest-chromium.json
@@ -23,8 +23,9 @@
         "open_in_tab": false
     },
     "permissions": [
-        "clipboardWrite",
         "activeTab",
+        "tabs",
+        "clipboardWrite",
         "nativeMessaging",
         "notifications",
         "webRequest",

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -21,8 +21,9 @@
         "open_in_tab": false
     },
     "permissions": [
-        "clipboardWrite",
         "activeTab",
+        "tabs",
+        "clipboardWrite",
         "nativeMessaging",
         "notifications",
         "webRequest",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1177900/55280524-f2ddde00-5326-11e9-92d2-0ca06feb043f.png)

Shows the number of entries that you will see if you open popup.

Performance-wise I haven't noticed any impact, it's all asynchronous anyway.

Fixes https://github.com/browserpass/browserpass/issues/292

`tabs` permission is needed because by the time `chrome.tabs.onUpdated` is called, user might be on another tab, so with the `activeTab` permission alone we aren't able to retrieve URL of the "old" tab.

There's a bit of duplication between popup and background... opportunity for future refactoring 😄 