### PR TITLE
Autosubmit forms by faking an Enter keypress

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -136,9 +136,13 @@
      * @since 3.0.0
      *
      * @param object request Form fill request
-     * @return void
+     * @return object result of focusing or submitting a form
      */
     function focusOrSubmit(request) {
+        var result = {
+            needPressEnter: false
+        };
+
         // get the login form
         var loginForm = form();
 
@@ -167,6 +171,10 @@
                 }
             } else {
                 // There is no submit button.
+                if (request.autoSubmit) {
+                    // signal background script that we want it to press Enter for us
+                    result.needPressEnter = true;
+                }
                 // We need to keep focus somewhere within the form, so that Enter hopefully submits the form.
                 var password = find(PASSWORD_FIELDS, loginForm);
                 if (password) {
@@ -179,6 +187,8 @@
                 }
             }
         }
+
+        return result;
     }
 
     /**

--- a/src/manifest-chromium.json
+++ b/src/manifest-chromium.json
@@ -23,6 +23,7 @@
         "open_in_tab": false
     },
     "permissions": [
+        "debugger",
         "activeTab",
         "tabs",
         "clipboardWrite",


### PR DESCRIPTION
Usual ways of dispatching Enter keypress don't submit forms, because `dispatchEvent` sets `Event.trusted` to `false` and browsers ignore it:

https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted

I found an interesting workaround that only works in Chromium(-based?) browser: debugger API.

Basically it allows us to issue "trusted" Enter keypresses, which do submit forms.

Sadly `debugger` permission is not supported by Firefox at all: 

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Browser_compatibility

Fixes https://github.com/browserpass/browserpass/issues/271
Fixes https://github.com/browserpass/browserpass/issues/268