### PR TITLE
Provide two .crx files as part of a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ VERSION ?= $(shell cat .version)
 
 CLEAN_FILES := chromium firefox dist
 CHROME := $(shell which chromium 2>/dev/null || which chromium-browser 2>/dev/null || which chrome 2>/dev/null || which google-chrome 2>/dev/null || which google-chrome-stable 2>/dev/null)
-PEM := $(shell find . -maxdepth 1 -name "*.pem")
 
 #######################
 # For local development
@@ -62,18 +61,18 @@ clean:
 	rm -rf $(CLEAN_FILES)
 	$(MAKE) -C src clean
 
-.PHONY: crx
-crx:
-ifneq ($(PEM),)
-	"$(CHROME)" --disable-gpu --pack-extension=./chromium --pack-extension-key=$(PEM)
-else
-	"$(CHROME)" --disable-gpu --pack-extension=./chromium
-	rm chromium.pem
-endif
-	mv chromium.crx browserpass.crx
+.PHONY: crx-webstore
+crx-webstore:
+	"$(CHROME)" --disable-gpu --pack-extension=./chromium --pack-extension-key=webstore.pem
+	mv chromium.crx browserpass-webstore.crx
+
+.PHONY: crx-github
+crx-github:
+	"$(CHROME)" --disable-gpu --pack-extension=./chromium --pack-extension-key=github.pem
+	mv chromium.crx browserpass-github.crx
 
 .PHONY: dist
-dist: clean extension chromium firefox crx
+dist: clean extension chromium firefox crx-webstore crx-github
 	mkdir -p dist
 
 	git archive -o dist/$(VERSION).tar.gz --format tar.gz --prefix=browserpass-extension-$(VERSION)/ $(VERSION)
@@ -81,7 +80,8 @@ dist: clean extension chromium firefox crx
 	(cd chromium && zip -FSr ../dist/chromium.zip *)
 	(cd firefox  && zip -FSr ../dist/firefox.zip  *)
 
-	mv browserpass.crx dist/
+	mv browserpass-webstore.crx dist/
+	mv browserpass-github.crx dist/
 
 	for file in dist/*; do \
 	    gpg --detach-sign "$$file"; \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ In order to install Browserpass correctly, you have to install two of its compon
 -   [Native messaging host](https://github.com/browserpass/browserpass-native#installation)
 -   Browser extension for Chromium-based browsers (choose one of the options):
     -   Install the extension from [Chrome Web Store](https://chrome.google.com/webstore/detail/browserpass-ce/naepdomgkenhinolocfifgehidddafch) (which will provide auto-updates)
-    -   Download `browserpass.crx` from the latest release and drag'n'drop it into `chrome://extensions` (remember to watch for new releases!).
+    -   Download `browserpass-webstore.crx` from the latest release and drag'n'drop it into `chrome://extensions`
+        -   This extension has the same ID as the one in Chrome Web Store, so when a new version will appear in Web Store, it will auto-update! Use if you want to be on latest and greatest version.
+    -   Download `browserpass-github.crx` from the latest release and drag'n'drop it into `chrome://extensions`
+        -   This extension has a different ID comparing to the one in Chrome Web Store, so you will not receive any auto-updates! Use for creating distro packages, or if you simply don't tolerate being forced to update when a new version is released.
     -   Download `chromium.zip`, unarchive and use `Load unpacked extension` in `chrome://extensions` in Developer mode.
 -   Browser extension for Firefox-based browsers (choose one of the options):
     -   Install the extension from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/browserpass-ce/) (which will provide auto-updates)


### PR DESCRIPTION
The new `browserpass-github.crx` can be used for creating distro packages for Browserpass extension, or if you don't want to get auto-updates.

Complementary PR: https://github.com/browserpass/browserpass-native/pull/38

For distro packagers, see [docs](https://developer.chrome.com/extensions/external_extensions#preferences):

`/usr/share/chromium/extensions/pjmbgaakjkbhpopmakjoedenlfdmcdgm.json`

```
{
    "external_crx": "/usr/lib/browserpass-chromium/browserpass-chromium.crx",
    "external_version": "3.0.3"
}
```