### PR TITLE
Switch to detecting outermost domain component

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -53,7 +53,7 @@ chrome.runtime.onInstalled.addListener(onExtensionInstalled);
 //----------------------------------- Function definitions ----------------------------------//
 
 /**
- * Get the deepest available domain component of a path
+ * Get the outermost available domain component of a path
  *
  * @since 3.0.0
  *
@@ -61,11 +61,8 @@ chrome.runtime.onInstalled.addListener(onExtensionInstalled);
  * @return string|null Extracted domain
  */
 function pathToDomain(path) {
-    var parts = path.split(/\//).reverse();
+    var parts = path.split(/\//);
     for (var key in parts) {
-        if (parts[key].indexOf("@") >= 0) {
-            continue;
-        }
         var t = TldJS.parse(parts[key]);
         if (t.isValid && t.domain !== null) {
             return t.hostname;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -30,7 +30,7 @@ function handleError(error, type = "error") {
 }
 
 /**
- * Get the deepest available domain component of a path
+ * Get the outermost available domain component of a path
  *
  * @since 3.0.0
  *
@@ -38,11 +38,8 @@ function handleError(error, type = "error") {
  * @return string|null Extracted domain
  */
 function pathToDomain(path) {
-    var parts = path.split(/\//).reverse();
+    var parts = path.split(/\//);
     for (var key in parts) {
-        if (parts[key].indexOf("@") >= 0) {
-            continue;
-        }
         var t = TldJS.parse(parts[key]);
         if (t.isValid && t.domain !== null) {
             return t.hostname;
@@ -105,6 +102,7 @@ async function run() {
                 logins.push(login);
             }
         }
+        console.log(logins);
         var popup = new Interface(settings, logins);
         popup.attach(document.body);
     } catch (e) {


### PR DESCRIPTION
@erayd need your opinion, why do we detect deepest available domain component instead of the outermost available one? We don't expect users to store "google.com/github.com.gpg", right? What was the use-case for this?

The reason I'm bringing this up is because someone reported to me a bug in person, that Browserpass does not correctly show the matching sites in popup.

For example, `~/.password-store/github.com/maxim.baz.gpg` will not show up on `github.com`, because according to our current parsing algorithm `maxim.baz` will be considered a domain name, not `github.com`.