### PR TITLE
Assume current domain is valid, even if the TLD is not

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -45,7 +45,12 @@ function pathToDomain(path, currentHost) {
             continue;
         }
         var t = TldJS.parse(parts[key]);
-        if (t.isValid && ((t.tldExists && t.domain !== null) || t.hostname === currentHost)) {
+        if (
+            t.isValid &&
+            ((t.tldExists && t.domain !== null) ||
+                t.hostname === currentHost ||
+                currentHost.endsWith(`.${t.hostname}`))
+        ) {
             return t.hostname;
         }
     }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -34,17 +34,18 @@ function handleError(error, type = "error") {
  *
  * @since 3.0.0
  *
- * @param string path Path to parse
+ * @param string path        Path to parse
+ * @param string currentHost Current hostname for the active tab
  * @return string|null Extracted domain
  */
-function pathToDomain(path) {
+function pathToDomain(path, currentHost) {
     var parts = path.split(/\//).reverse();
     for (var key in parts) {
         if (parts[key].indexOf("@") >= 0) {
             continue;
         }
         var t = TldJS.parse(parts[key]);
-        if (t.isValid && t.tldExists && t.domain !== null) {
+        if (t.isValid && ((t.tldExists && t.domain !== null) || t.hostname === currentHost)) {
             return t.hostname;
         }
     }
@@ -92,7 +93,7 @@ async function run() {
                     login: response.files[storeId][key].replace(/\.gpg$/i, ""),
                     allowFill: true
                 };
-                login.domain = pathToDomain(storeId + "/" + login.login);
+                login.domain = pathToDomain(storeId + "/" + login.login, settings.host);
                 login.inCurrentDomain =
                     settings.host == login.domain || settings.host.endsWith("." + login.domain);
                 login.recent =


### PR DESCRIPTION
When checking path elements for domain-ness, assume that the current tab hostname is a valid domain, even if it doesn't use a legitimate TLD.

Fixes #99.