### PR TITLE
Use getAttribute to safely read attribute value

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -319,10 +319,11 @@
         // Try to filter only forms that have some identifying marker
         const markedForms = [];
         for (let form of forms) {
-            const props = [form.id, form.name, form.className, form.action];
+            const props = ["id", "name", "class", "action"];
             for (let marker of FORM_MARKERS) {
                 for (let prop of props) {
-                    if (prop.toLowerCase().indexOf(marker) > -1) {
+                    let propValue = form.getAttribute(prop) || "";
+                    if (propValue.toLowerCase().indexOf(marker) > -1) {
                         markedForms.push(form);
                     }
                 }


### PR DESCRIPTION
`form.action` returns both attribute on a `<form>` tag, but when it's not present, it returns an element (!) with `name="action"` inside that form. This causes https://github.com/browserpass/browserpass-extension/issues/62#issuecomment-482991198

By using `getAttribute` we can safely read the form attribute value, which returns either a string or `null`.