### PR TITLE
Prevent duplicate install notifications

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1014,12 +1014,15 @@ function onExtensionInstalled(details) {
     };
 
     if (details.reason === "install") {
-        show(
-            "installed",
-            "browserpass: Install native host app",
-            "Remember to install the complementary native host app to use this extension.\n" +
-                "Instructions here: https://github.com/browserpass/browserpass-native"
-        );
+        if (!("installed" in localStorage)) {
+            localStorage.setItem("installed", Date.now());
+            show(
+                "installed",
+                "browserpass: Install native host app",
+                "Remember to install the complementary native host app to use this extension.\n" +
+                    "Instructions here: https://github.com/browserpass/browserpass-native"
+            );
+        }
     } else if (details.reason === "update") {
         var changelog = {
             3000000:

--- a/src/background.js
+++ b/src/background.js
@@ -1014,7 +1014,7 @@ function onExtensionInstalled(details) {
     };
 
     if (details.reason === "install") {
-        if (!("installed" in localStorage)) {
+        if (localStorage.getItem("installed") === null) {
             localStorage.setItem("installed", Date.now());
             show(
                 "installed",


### PR DESCRIPTION
The way Debian's `browserpass-webext` package side-loads Browserpass extension makes Chromium trigger "installed" event every time a browser is restarted. Luckily the localStorage is persisted between restarts, so we can store some marker there, distinguishing the first installation from a subsequent one.

If a user _removes_ the extension, browser will purge everything, so if this user installs it again, they will see a notification again, as it will be a proper first installation.

We could theoretically store anything as a marker, I figure an installation timestamp could serve us well one day (e.g. if we will ever need to find a subset of users who installed the extension withing a certain period of time).

