### PR TITLE
Handle inability to inject script to all frames

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -304,11 +304,12 @@ async function injectScript(settings, allFrames) {
     const MAX_WAIT = 1000;
 
     return new Promise(async (resolve, reject) => {
-        setTimeout(reject, MAX_WAIT);
+        const waitTimeout = setTimeout(reject, MAX_WAIT);
         await chrome.tabs.executeScript(settings.tab.id, {
             allFrames: allFrames,
             file: "js/inject.dist.js"
         });
+        clearTimeout(waitTimeout);
         resolve(true);
     });
 }
@@ -333,7 +334,9 @@ async function fillFields(settings, login, fields) {
     try {
         await injectScript(settings, true);
         injectedAllFrames = true;
-    } catch {}
+    } catch {
+        // we'll proceed with trying to fill only the top frame
+    }
 
     // build fill request
     var fillRequest = {


### PR DESCRIPTION
Chromium can hang indefinitely trying to inject a script to certain kinds of iframes, such as the one present on `ox.credativ.com` (https://github.com/browserpass/browserpass-extension/issues/62#issuecomment-484020195). The workaround is to wait at most 1 second, and then abort the injection.

Hopefully `1 sec` is more than enough for normal cases and we won't mess with anybody's Browserpass, if we see user reports about "Error: Unable to inject script in the top frame", we must increase this timeout.