### PR TITLE
WIP: Automatically add passwords to password store

### DIFF
--- a/src/background-interject.js
+++ b/src/background-interject.js
@@ -1,0 +1,56 @@
+module.exports = { extractFormData: extractFormData };
+
+const USERNAME_KEYS = ["username", "user", "login"];
+const EMAIL_KEYS = ["email", "e-mail"];
+const PASSWORD_KEYS = ["password", "passwd", "pass", "secret"];
+
+function findFormDataEntries(formData, keys) {
+    let found = [];
+
+    for (key in formData) {
+        if (keys.includes(key)) {
+            let entry = formData[key];
+            if (entry != "") found.push(entry[0]);
+        }
+    }
+
+    return found;
+}
+
+function checkPasswords(passwords) {
+    if (passwords.length < 2) return true;
+
+    let compare = passwords[0];
+
+    for (let password of passwords) {
+        if (password != compare) return false;
+    }
+
+    return true;
+}
+
+function extractFormData(formData) {
+    let passwords = findFormDataEntries(formData, PASSWORD_KEYS);
+    let usernames = findFormDataEntries(formData, USERNAME_KEYS);
+    let emails = findFormDataEntries(formData, EMAIL_KEYS);
+
+    if (!checkPasswords(passwords)) return null;
+
+    if (passwords.length === 0) return null;
+
+    if (usernames.length === 0 && emails.length === 0) return null;
+
+    let credentials = { password: passwords[0] };
+    if (usernames.length > 0) {
+        credentials.login = usernames[0];
+
+        if (emails.length > 0) {
+            credentials.email = emails[0];
+        }
+    } else {
+        credentials.login = emails[0];
+        credentials.email = "";
+    }
+
+    return credentials;
+}

--- a/src/background-interject.js
+++ b/src/background-interject.js
@@ -8,7 +8,14 @@ function findFormDataEntries(formData, keys) {
     let found = [];
 
     for (key in formData) {
-        if (keys.includes(key)) {
+	// strip keys of the form user[x]
+        let strippedKey = key;
+        let match = /\[.*\]/.exec(key);
+        if (match) {
+            strippedKey = key.substring(match.index + 1, match.index + match[0].length - 1);
+        }
+
+        if (keys.includes(strippedKey)) {
             let entry = formData[key];
             if (entry != "") found.push(entry[0]);
         }

--- a/src/background.js
+++ b/src/background.js
@@ -781,7 +781,7 @@ async function handleMessage(settings, message, sendResponse) {
         case "create":
             try {
                 response = await hostAction(settings, "create", {
-                    storeID: settings.stores.default.id,
+                    storeID: message.storeID,
                     credentials: message.credentials,
                     file: message.credentials.path
                 });

--- a/src/background.js
+++ b/src/background.js
@@ -58,6 +58,9 @@ let dismissedCredentials = new Set();
 chrome.webRequest.onBeforeRequest.addListener(
     async function(details) {
         if (details.method == "POST") {
+            if (!details.requestBody) {
+                return;
+            }
             let formData = details.requestBody.formData;
             if (!formData) {
                 return;

--- a/src/inject.js
+++ b/src/inject.js
@@ -99,7 +99,6 @@
         if (!request.allowNoSecret && !find(PASSWORD_FIELDS, loginForm)) {
             return result;
         }
-
         // ensure the origin is the same, or ask the user for permissions to continue
         if (window.location.origin !== request.origin) {
             if (!request.allowForeign || request.foreignFills[window.location.origin] === false) {

--- a/src/popup/add-interface.js
+++ b/src/popup/add-interface.js
@@ -1,0 +1,89 @@
+module.exports = AddInterface;
+var m = require("mithril");
+
+function AddInterface(credentials, settings) {
+    // public methods
+    this.attach = attach;
+    this.view = view;
+
+    // fields
+    this.settings = settings;
+    this.credentials = credentials;
+    this.dismissCredential = dismissCredential;
+}
+
+function attach(element) {
+    m.mount(element, this);
+}
+
+function view(ctl, params) {
+    let credentials = this.credentials.length > 0 ? this.credentials[0] : undefined;
+
+    var nodes = [];
+
+    nodes.push(m("div.label.title", "Save credentials to store?"));
+
+    nodes.push(m("div.label", "Path:"));
+    nodes.push(
+        m("input.credential", {
+            type: "text",
+            value: credentials ? credentials.path : ""
+        })
+    );
+
+    nodes.push(m("div.label", "Username:"));
+    nodes.push(
+        m("input.credential", {
+            type: "text",
+            value: credentials ? credentials.login : ""
+        })
+    );
+
+    nodes.push(m("div.label", "Password:"));
+    nodes.push(
+        m("input.credential", {
+            type: "password",
+            value: credentials ? credentials.password : ""
+        })
+    );
+
+    if (credentials.email) {
+        nodes.push(m("div.label", "E-Mail:"));
+        nodes.push(
+            m("input.credential", {
+                type: "text",
+                value: credentials ? credentials.email : ""
+            })
+        );
+    }
+
+    nodes.push(
+        m("div.buttons", [
+            m(
+                "button.storeButton",
+                {
+                    onclick: async function(e) {
+                        await credentials.doAction("create");
+                    }
+                },
+                "Yes"
+            ),
+            m(
+                "button.storeButton",
+                {
+                    onclick: async function(e) {
+                        await credentials.doAction("dismiss");
+                    }
+                },
+                "No"
+            )
+        ])
+    );
+
+    return nodes;
+}
+
+function dismissCredential() {
+    this.credentials.shift();
+    return this.credentials.length;
+}

--- a/src/popup/add-interface.js
+++ b/src/popup/add-interface.js
@@ -23,6 +23,14 @@ function view(ctl, params) {
 
     nodes.push(m("div.label.title", "Save credentials to store?"));
 
+    nodes.push(m("div.label", "Store:"));
+    let select = m(
+        "select",
+        Object.values(this.settings.stores).map(store =>
+            m("option", { storeID: store.id }, store.name)
+        )
+    );
+    nodes.push(select);
     nodes.push(m("div.label", "Path:"));
     nodes.push(
         m("input.credential", {
@@ -63,7 +71,8 @@ function view(ctl, params) {
                 "button.storeButton",
                 {
                     onclick: async function(e) {
-                        await credentials.doAction("create");
+                        let storeID = select.dom.selectedOptions[0].getAttribute("storeID");
+                        await credentials.doAction("create", storeID);
                     }
                 },
                 "Yes"

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -192,11 +192,12 @@ async function withLogin(action) {
     }
 }
 
-async function withCredential(action) {
+async function withCredential(action, storeID) {
     const credentials = JSON.parse(JSON.stringify(this.credentials));
     let response = await chrome.runtime.sendMessage({
         action: action,
-        credentials: credentials
+        credentials: credentials,
+        storeID: storeID
     });
 
     switch (action) {

--- a/src/popup/popup.less
+++ b/src/popup/popup.less
@@ -234,3 +234,45 @@ body {
         color: @error-text-color;
     }
 }
+
+.buttons {
+    display: flex;
+    flex-direction: row;
+    height: @login-height;
+}
+
+.storeButton {
+    width: 100%;
+    border: none;
+    background-color: @bg-color;
+    font-size: 16px;
+    overflow: hidden;
+    color: @text-color;
+    outline: none;
+}
+
+.storeButton:hover,
+.storeButton:focus {
+    background-color: @hover-bg-color;
+}
+
+.label,
+.credential {
+    font-size: 16px;
+}
+
+.title {
+    text-align: center;
+    font-size: 20px;
+    width: 100%;
+    background-color: @hover-bg-color;
+}
+
+textarea:focus,
+input:focus {
+    outline: none;
+}
+
+*:focus {
+    outline: none;
+}

--- a/src/popup/popup.less
+++ b/src/popup/popup.less
@@ -276,3 +276,20 @@ input:focus {
 *:focus {
     outline: none;
 }
+
+select {
+    // -moz-appearance: none;
+    // -webkit-appearance: none;
+    appearance: none;
+    border: none;
+    width: 100%;
+    // height: 20px;
+    background-color: #fff;
+    color: #000;
+    font-size: 16px;
+}
+
+select,
+.credential {
+    height: 25px;
+}


### PR DESCRIPTION
Hi Guys,

I hacked on this project a little bit and added a prototype UI and the functionality to conveniently add passwords to the password store, according to #61. The credentials are pulled from HTTP requests whenever the user submits a form. If the credentials don't exist in the password store yet, they are shown in the popup window, in a new UI, along with buttons to either save or dismiss the credentials. The user is also able to choose a store from the UI and change the credentials/the path in which they are stored. When saving, the password file is also properly checked in to the git repository of the password store. When dismissed, the credentials are memorized (should probably be hashed) so that the user is not bothered by the popup when he submits these credentials again.

![image](https://user-images.githubusercontent.com/23345247/56980497-cf53c080-6b7c-11e9-9986-c8bb4580c954.png)

These changes are still WIP but I would like to keep working on them until this PR is deemed ready to be merged. Please take a look at it and let's discuss what needs to be done and in which way the new feature should be designed. I'll create a PR with the corresponding host changes in the browserpass-native repository.