### PR TITLE
Set an explicit, stricter CSP

### DIFF
--- a/src/manifest-chromium.json
+++ b/src/manifest-chromium.json
@@ -38,6 +38,7 @@
         "http://*/*",
         "https://*/*"
     ],
+    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'",
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -35,6 +35,7 @@
         "http://*/*",
         "https://*/*"
     ],
+    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'",
     "applications": {
         "gecko": {
             "id": "browserpass@maximbaz.com",


### PR DESCRIPTION
The Chrome and Firefox extension manifests allow the developer to specify a custom Content Security Policy, which is then applied to all parts of the extension with access to the privileged `chrome.*` API. Out of an abundance of caution, and in order to document benign browserpass behavior, we could use this feature to declare an explicit CSP that is as strict as possible.

The CSP proposed by this PR disallows everything other than embedding fonts, images, scripts and styles from files shipped with the extension.