### PR TITLE
Add option to ignore entries matching a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Browserpass was designed with an assumption that certain conventions are being f
 
 1. URL ([only](#password-matching-and-sorting) used for [modal HTTP authentication](#modal-http-authentication)!) must be defined on a line starting with `url:`, `uri:`, `website:`, `site:`, `link:` or `launch:` (case-insensitive).
 
+If there are entries in your password store that you do not wish to see via Browserpass, you can ignore them by setting the `ignore` option in `.browserpass.json`. This is defined as either a string, or an array of strings, using the standard `.gitignore` syntax. Any matching files or directories will be completely ignored.
+
 ### First steps in browser extension
 
 Click on the icon or use <kbd>Ctrl+Shift+L</kbd> to open the Browserpass popup with the entries that match the current domain. You can also use <kbd>Ctrl+Shift+F</kbd> to fill the form with the best matching credentials without even opening the popup (the best matching credentials are the first ones on the list if you open the popup).
@@ -218,6 +220,7 @@ The list of available options:
 | Custom store locations                                          | List of password stores to use                               |
 | Custom store locations - badge background color (aka `bgColor`) | Badge background color for a given password store in popup   |
 | Custom store locations - badge text color (aka `color`)         | Badge text color for a given password store in popup         |
+| Ignore items (aka `ignore`)                                     | Ignore all matching logins                                   |
 
 Browserpass allows configuring certain settings in different places places using the following priority, highest first:
 
@@ -229,6 +232,7 @@ Browserpass allows configuring certain settings in different places places using
     - `username`
     - `bgColor`
     - `color`
+    - `ignore`
 1. Options defined in browser extension options:
     - Automatically submit forms after filling (aka `autoSubmit`)
     - Default username (aka `username`)

--- a/src/background.js
+++ b/src/background.js
@@ -121,7 +121,7 @@ async function updateMatchingPasswordsCount(tabId) {
             throw new Error(`Unable to determine domain of the tab with id ${tabId}`);
         }
 
-        const files = helpers.ignoreFiles(settings, response.data.files);
+        const files = helpers.ignoreFiles(response.data.files, settings);
         const logins = helpers.prepareLogins(files, settings);
         const matchedPasswordsCount = logins.reduce(
             (acc, login) => acc + (login.recent.count || login.inCurrentDomain ? 1 : 0),
@@ -715,7 +715,7 @@ async function handleMessage(settings, message, sendResponse) {
                 if (response.status != "ok") {
                     throw new Error(JSON.stringify(response)); // TODO handle host error
                 }
-                let files = helpers.ignoreFiles(settings, response.data.files);
+                let files = helpers.ignoreFiles(response.data.files, settings);
                 sendResponse({ status: "ok", files });
             } catch (e) {
                 sendResponse({

--- a/src/background.js
+++ b/src/background.js
@@ -121,7 +121,8 @@ async function updateMatchingPasswordsCount(tabId) {
             throw new Error(`Unable to determine domain of the tab with id ${tabId}`);
         }
 
-        const logins = helpers.prepareLogins(response.data.files, settings);
+        const files = helpers.ignoreFiles(settings, response.data.files);
+        const logins = helpers.prepareLogins(files, settings);
         const matchedPasswordsCount = logins.reduce(
             (acc, login) => acc + (login.recent.count || login.inCurrentDomain ? 1 : 0),
             0
@@ -714,7 +715,8 @@ async function handleMessage(settings, message, sendResponse) {
                 if (response.status != "ok") {
                     throw new Error(JSON.stringify(response)); // TODO handle host error
                 }
-                sendResponse({ status: "ok", files: response.data.files });
+                let files = helpers.ignoreFiles(settings, response.data.files);
+                sendResponse({ status: "ok", files });
             } catch (e) {
                 sendResponse({
                     status: "error",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,11 +4,13 @@
 const FuzzySort = require("fuzzysort");
 const TldJS = require("tldjs");
 const sha1 = require("sha1");
+const ignore = require("ignore");
 
 module.exports = {
     pathToDomain,
     prepareLogins,
-    filterSortLogins
+    filterSortLogins,
+    ignoreFiles
 };
 
 //----------------------------------- Function definitions ----------------------------------//
@@ -259,6 +261,33 @@ function highlightMatches(entry, fuzzyResults, substringFilters) {
         path: path,
         display: display
     });
+}
+
+/**
+ * Filter out ignored files according to .browserpass.json rules
+ *
+ * @since 3.1.2
+ *
+ * @param object settings Settings object
+ * @param object files    Arrays of files, grouped by store
+ * @return object Filtered arrays of files, grouped by store
+ */
+function ignoreFiles(settings, files) {
+    let filteredFiles = {};
+    for (let store in files) {
+        let storeSettings = settings.stores[store].settings;
+        if (storeSettings.hasOwnProperty("ignore")) {
+            if (typeof storeSettings.ignore === "string") {
+                storeSettings.ignore = [storeSettings.ignore];
+            }
+            filteredFiles[store] = ignore()
+                .add(storeSettings.ignore)
+                .filter(files[store]);
+        } else {
+            filteredFiles[store] = files[store];
+        }
+    }
+    return filteredFiles;
 }
 
 /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -266,13 +266,13 @@ function highlightMatches(entry, fuzzyResults, substringFilters) {
 /**
  * Filter out ignored files according to .browserpass.json rules
  *
- * @since 3.1.2
+ * @since 3.2.0
  *
- * @param object settings Settings object
  * @param object files    Arrays of files, grouped by store
+ * @param object settings Settings object
  * @return object Filtered arrays of files, grouped by store
  */
-function ignoreFiles(settings, files) {
+function ignoreFiles(files, settings) {
     let filteredFiles = {};
     for (let store in files) {
         let storeSettings = settings.stores[store].settings;

--- a/src/package.json
+++ b/src/package.json
@@ -18,6 +18,7 @@
         "chrome-extension-async": "^3.3.2",
         "fuzzysort": "^1.1.4",
         "idb": "^4.0.3",
+        "ignore": "^5.1.4",
         "mithril": "^1.1.0",
         "moment": "^2.24.0",
         "sha1": "^1.1.1",

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -706,6 +706,11 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
 
+ignore@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"


### PR DESCRIPTION
## What
Adds an `ignore` option to `browserpass.json`. This takes either a string or an array of strings, with each string being a pattern using the standard `.gitignore` syntax. All matching files will be completely ignored by Browserpass.

## Why
Because I have a fair amount of stuff stored in my pass repo which shows up by default in Browserpass, but really shouldn't (e.g. SSH passwords, HTTPS certificates, decryption passwords for associated keys, etc).