### PR TITLE
Reduce number of calls to host app when computing badge counters

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -124,13 +124,21 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
 
         // Calculate number of matching password
         if (!(hostname in badgeCounters)) {
+            // Mark the entry as processing, to avoid running block below simultaneously
+            badgeCounters[hostname] = 0;
+
+            // Get settings
             const settings = await getFullSettings();
             var response = await hostAction(settings, "list");
             if (response.status != "ok") {
+                // Mark the entry to be refreshed on next run
+                delete badgeCounters[hostname];
+
                 throw new Error(JSON.stringify(response));
             }
             settings.host = hostname;
 
+            // Compule badge counter
             const files = helpers.ignoreFiles(response.data.files, settings);
             const logins = helpers.prepareLogins(files, settings);
             badgeCounters[hostname] = logins.reduce(

--- a/src/background.js
+++ b/src/background.js
@@ -118,7 +118,6 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
                 settings: null,
                 expires: Date.now() + 60 * 1000
             };
-            console.log("refreshing!!");
 
             badgeCache.settings = await getFullSettings();
 


### PR DESCRIPTION
@erayd what do you think of such naive caching approach? I didn't want to deal with tab management (monitoring when user navigates between tabs, when URL in the tab is changed, when tab is opened or closed, etc.), so instead on _every_ tab event a badge is refreshed. However now the badge counter is cached per hostname, so in majority of cases the code will not attempt to talk to host app.

I recommend reviewing with `?w=1`

Fixes #135 
Fixes #138
