### PR TITLE
Support and prioritize fields with autocomplete attributes

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -6,6 +6,7 @@
     };
     const USERNAME_FIELDS = {
         selectors: [
+            "input[autocomplete=username i]",
             "input[name*=login i]",
             "input[name*=user i]",
             "input[name*=email i]",
@@ -22,7 +23,10 @@
         types: ["email", "text", "tel"]
     };
     const PASSWORD_FIELDS = {
-        selectors: ["input[type=password i]"]
+        selectors: [
+            "input[type=password i][autocomplete=current-password i]",
+            "input[type=password i]"
+        ]
     };
     const INPUT_FIELDS = {
         selectors: PASSWORD_FIELDS.selectors


### PR DESCRIPTION
Fixes #148 

When an `autocomplete=username` or `autocomplete=current-password` is present, it is developers' hint to us that these are the login and password fields.

I haven't actually noticed these being used in the wild, but if they are, we should try to respect and prioritize them.

With this change, any input which has `autocomplete=username` is considered first to be a username field, and any _password_ field which has `autocomplete=current-password` is prioritized over any other password fields.