### PR TITLE
Replace tldjs with @browserpass/url, check port

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ Note: If the cursor is located in the search input field, every shortcut that wo
 
 ### Password matching and sorting
 
-When you first open the Browserpass popup, you will see a badge with the current domain in the search input field:
+When you first open the Browserpass popup, you will see a badge with the current domain name in the search input field:
 
 ![image](https://user-images.githubusercontent.com/1177900/54785353-52046a00-4c26-11e9-8497-8dc50701ddc4.png)
 
-This means that phishing attack prevention is enabled, and Browserpass is only showing you entries from your password store that match this host.
+This means that phishing attack prevention is enabled, and Browserpass is only showing you entries from your password store that match this domain.
 
 In order for Browserpass to correctly determine matching entries, it is expected that your password store follows naming conventions (see [Organizing password store](#organizing-password-store)). In particular your file or folder name must contain a domain with a valid TLD, i.e. not `github.gpg`, but `github.com.gpg`. If an attacker directed you to `https://github.co/login` (notice `.co`), Browserpass will **not** present `github.com` entry in the popup. However if you intentionally want to re-use the same credentials on multiple domains (e.g. `amazon.com` and `amazon.co.uk`), see [How to use the same username and password pair on multiple domains](#how-to-use-the-same-username-and-password-pair-on-multiple-domains).
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If not, repeat the installation instructions for the extension.
 
 Browserpass was designed with an assumption that certain conventions are being followed when organizing your password store.
 
-1. In order to benefit of phishing attack protection, a password entry file, or any of its parent folders, must contain a full domain name (including TLD like `.com`) in their name in order to automatically match a website. However, entries which do not contain such a domain in their name may still be manually selected.
+1. In order to benefit of phishing attack protection, a password entry file, or any of its parent folders, must contain a full domain name (including TLD like `.com`) and optionally port in their name in order to automatically match a website. However, entries which do not contain such a domain in their name may still be manually selected.
 
     File names are not allowed to contain `\` or `/` characters, because both of them are considered to be path separators.
 
@@ -161,15 +161,17 @@ Note: If the cursor is located in the search input field, every shortcut that wo
 
 ### Password matching and sorting
 
-When you first open the Browserpass popup, you will see a badge with the current domain name in the search input field:
+When you first open the Browserpass popup, you will see a badge with the current host in the search input field:
 
 ![image](https://user-images.githubusercontent.com/1177900/54785353-52046a00-4c26-11e9-8497-8dc50701ddc4.png)
 
-This means that phishing attack prevention is enabled, and Browserpass is only showing you entries from your password store that match this domain.
+This means that phishing attack prevention is enabled, and Browserpass is only showing you entries from your password store that match this host.
 
 In order for Browserpass to correctly determine matching entries, it is expected that your password store follows naming conventions (see [Organizing password store](#organizing-password-store)). In particular your file or folder name must contain a domain with a valid TLD, i.e. not `github.gpg`, but `github.com.gpg`. If an attacker directed you to `https://github.co/login` (notice `.co`), Browserpass will **not** present `github.com` entry in the popup. However if you intentionally want to re-use the same credentials on multiple domains (e.g. `amazon.com` and `amazon.co.uk`), see [How to use the same username and password pair on multiple domains](#how-to-use-the-same-username-and-password-pair-on-multiple-domains).
 
 Browserpass will display entries for the current domain, as well as all parent entries, but not entries from different subdomains. Suppose you are currently on `https://v3.app.example.com`, Browserpass will present all the following entries in popup (if they exist): `v3.app.example.com`, `app.example.com`, `example.com`; but it will not present entries like `v2.app.example.com` or `wiki.example.com`.
+
+Browserpass can also distinguish credentials meant for different ports, so for example an entry `example.com.gpg` will show up in Browserpass popup when you browse `example.com` on any port, however an entry `example.com:8080.gpg` will only show up on `8080` port.
 
 Finally Browserpass will also present entries that you have recently used on this domain, even if they don't actually meet the usual matching requirements. Suppose you have a password for `amazon.com`, but you open `https://amazon.co.uk`, at first Browserpass will present no entries (because nothing matches `amazon.co.uk`), but if you hit <kbd>Backspace</kbd>, find `amazon.com` and use it to login, next time you visit `https://amazon.co.uk` and open Browserpass, `amazon.com` entry will already be present.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Note: If the cursor is located in the search input field, every shortcut that wo
 
 ### Password matching and sorting
 
-When you first open the Browserpass popup, you will see a badge with the current host in the search input field:
+When you first open the Browserpass popup, you will see a badge with the current domain in the search input field:
 
 ![image](https://user-images.githubusercontent.com/1177900/54785353-52046a00-4c26-11e9-8497-8dc50701ddc4.png)
 

--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@
 require("chrome-extension-async");
 const sha1 = require("sha1");
 const idb = require("idb");
+const BrowserpassURL = require("@browserpass/url");
 const helpers = require("./helpers");
 
 // native application id
@@ -581,7 +582,9 @@ async function getFullSettings() {
     // Fill current tab info
     try {
         settings.tab = (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
-        settings.host = new URL(settings.tab.url).host;
+        let originInfo = new BrowserpassURL(settings.tab.url);
+        settings.host = originInfo.host;
+        settings.origin = originInfo.origin;
     } catch (e) {}
 
     return settings;
@@ -1084,6 +1087,7 @@ function triggerOTPExtension(settings, action, otp) {
                 otp: otp,
                 settings: {
                     host: settings.host,
+                    origin: settings.origin,
                     tab: settings.tab
                 }
             })

--- a/src/background.js
+++ b/src/background.js
@@ -772,7 +772,7 @@ async function handleMessage(settings, message, sendResponse) {
         case "launch":
         case "launchInNewTab":
             try {
-                var url = message.login.fields.url || message.login.domain;
+                var url = message.login.fields.url || message.login.host;
                 if (!url) {
                     throw new Error("No URL is defined for this entry");
                 }

--- a/src/background.js
+++ b/src/background.js
@@ -146,7 +146,7 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
         const files = helpers.ignoreFiles(badgeCache.files, badgeCache.settings);
         const logins = helpers.prepareLogins(files, badgeCache.settings);
         const matchedPasswordsCount = logins.reduce(
-            (acc, login) => acc + (login.recent.count || login.inCurrentDomain ? 1 : 0),
+            (acc, login) => acc + (login.recent.count || login.inCurrentHost ? 1 : 0),
             0
         );
 
@@ -234,7 +234,7 @@ async function saveRecent(settings, login, remove = false) {
     localStorage.setItem("recent", JSON.stringify(settings.recent));
 
     // a new entry was added to the popup matching list, need to refresh the count
-    if (!login.inCurrentDomain && login.recent.count === 1) {
+    if (!login.inCurrentHost && login.recent.count === 1) {
         updateMatchingPasswordsCount(settings.tab.id, true);
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -138,7 +138,7 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
 
         try {
             const tab = await chrome.tabs.get(tabId);
-            badgeCache.settings.host = new URL(tab.url).host;
+            badgeCache.settings.origin = new URL(tab.url).origin;
         } catch (e) {
             throw new Error(`Unable to determine domain of the tab with id ${tabId}`);
         }
@@ -229,7 +229,8 @@ async function saveRecent(settings, login, remove = false) {
         login.recent.count++;
     }
     login.recent.when = Date.now();
-    settings.recent[sha1(settings.host + sha1(login.store.id + sha1(login.login)))] = login.recent;
+    settings.recent[sha1(settings.origin + sha1(login.store.id + sha1(login.login)))] =
+        login.recent;
 
     // save to local storage
     localStorage.setItem("recent", JSON.stringify(settings.recent));
@@ -247,7 +248,7 @@ async function saveRecent(settings, login, remove = false) {
                 db.createObjectStore("log", { keyPath: "time" });
             }
         });
-        await db.add("log", { time: Date.now(), host: settings.host, login: login.login });
+        await db.add("log", { time: Date.now(), host: settings.origin, login: login.login });
     } catch {
         // ignore any errors and proceed without saving a log entry to Indexed DB
     }
@@ -267,7 +268,7 @@ async function dispatchFill(settings, request, allFrames, allowForeign, allowNoS
     request = Object.assign(deepCopy(request), {
         allowForeign: allowForeign,
         allowNoSecret: allowNoSecret,
-        foreignFills: settings.foreignFills[settings.host] || {}
+        foreignFills: settings.foreignFills[settings.origin] || {}
     });
 
     let perFrameResults = await chrome.tabs.executeScript(settings.tab.id, {
@@ -285,10 +286,10 @@ async function dispatchFill(settings, request, allFrames, allowForeign, allowNoS
     let foreignFillsChanged = false;
     for (let frame of perFrameResults) {
         if (typeof frame.foreignFill !== "undefined") {
-            if (typeof settings.foreignFills[settings.host] === "undefined") {
-                settings.foreignFills[settings.host] = {};
+            if (typeof settings.foreignFills[settings.origin] === "undefined") {
+                settings.foreignFills[settings.origin] = {};
             }
-            settings.foreignFills[settings.host][frame.foreignOrigin] = frame.foreignFill;
+            settings.foreignFills[settings.origin][frame.foreignOrigin] = frame.foreignFill;
             foreignFillsChanged = true;
         }
     }
@@ -311,7 +312,7 @@ async function dispatchFill(settings, request, allFrames, allowForeign, allowNoS
 async function dispatchFocusOrSubmit(settings, request, allFrames, allowForeign) {
     request = Object.assign(deepCopy(request), {
         allowForeign: allowForeign,
-        foreignFills: settings.foreignFills[settings.host] || {}
+        foreignFills: settings.foreignFills[settings.origin] || {}
     });
 
     let perFrameResults = await chrome.tabs.executeScript(settings.tab.id, {
@@ -418,7 +419,7 @@ async function fillFields(settings, login, fields) {
         // try again using all available frames if we couldn't fill an "important" field
         if (
             !filledFields.includes(importantFieldToFill) &&
-            settings.foreignFills[settings.host] !== false
+            settings.foreignFills[settings.origin] !== false
         ) {
             allowForeign = true;
             filledFields = filledFields.concat(
@@ -456,7 +457,7 @@ async function fillFields(settings, login, fields) {
             }
 
             // try again using all available frames
-            if (!filledFields.length && settings.foreignFills[settings.host] !== false) {
+            if (!filledFields.length && settings.foreignFills[settings.origin] !== false) {
                 allowForeign = true;
                 filledFields = filledFields.concat(
                     await dispatchFill(
@@ -583,7 +584,7 @@ async function getFullSettings() {
     try {
         settings.tab = (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
         let originInfo = new BrowserpassURL(settings.tab.url);
-        settings.host = originInfo.host;
+        settings.host = originInfo.host; // TODO remove this after OTP extension is migrated
         settings.origin = originInfo.origin;
     } catch (e) {}
 

--- a/src/background.js
+++ b/src/background.js
@@ -137,7 +137,7 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
 
         try {
             const tab = await chrome.tabs.get(tabId);
-            badgeCache.settings.host = new URL(tab.url).hostname;
+            badgeCache.settings.host = new URL(tab.url).host;
         } catch (e) {
             throw new Error(`Unable to determine domain of the tab with id ${tabId}`);
         }
@@ -581,7 +581,7 @@ async function getFullSettings() {
     // Fill current tab info
     try {
         settings.tab = (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
-        settings.host = new URL(settings.tab.url).hostname;
+        settings.host = new URL(settings.tab.url).host;
     } catch (e) {}
 
     return settings;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,8 +20,8 @@ module.exports = {
  * @since 3.2.3
  *
  * @param string path        Path to parse
- * @param string currentHost Current hostname for the active tab
- * @return string|null Extracted domain info
+ * @param object currentHost Current host info for the active tab
+ * @return object|null Extracted domain info
  */
 function pathToInfo(path, currentHost) {
     var parts = path.split(/\//).reverse();
@@ -33,12 +33,12 @@ function pathToInfo(path, currentHost) {
 
         // Part is considered to be a domain component in one of the following cases:
         // - it is a valid domain with well-known TLD (github.com, login.github.com)
-        // - it is or isn't a valid domain with unknown TLD but the current host is its subdomain (login.pi.hole)
-        // - it is or isn't a valid domain but the current host matches it EXACTLY (localhost, pi.hole)
+        // - it is or isn't a valid domain with any TLD but the current host matches it EXACTLY (localhost, pi.hole)
+        // - it is or isn't a valid domain with any TLD but the current host is its subdomain (login.pi.hole)
         if (
             info.validDomain ||
-            currentHost.hostname.endsWith(`.${info.hostname}`) ||
-            currentHost.hostname === info.hostname
+            currentHost.hostname === info.hostname ||
+            currentHost.hostname.endsWith(`.${info.hostname}`)
         ) {
             return info;
         }
@@ -83,9 +83,12 @@ function prepareLogins(files, settings) {
                 login.inCurrentHost = host.hostname === pathInfo.hostname;
 
                 // check whether the current origin is subordinate to extracted path info, meaning:
-                //  - that the path info is not a single level (e.g. com, net, local)
-                //  - and that the host ends with that path info
-                if (pathInfo.hostname.includes(".") && host.hostname.endsWith(pathInfo.hostname)) {
+                //  - that the path info is not a single level domain (e.g. com, net, local)
+                //  - and that the current origin is a subdomain of that path info
+                if (
+                    pathInfo.hostname.includes(".") &&
+                    host.hostname.endsWith(`.${pathInfo.hostname}`)
+                ) {
                     login.inCurrentHost = true;
                 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -72,9 +72,11 @@ function prepareLogins(files, settings) {
                 allowFill: true
             };
             let domainInfo = pathToDomainInfo(storeId + "/" + login.login, settings.host);
-            login.domain = domainInfo ? domainInfo.hostname : null;
+            login.domain = domainInfo ? domainInfo.hostname : "";
             login.inCurrentHost =
-                host.hostname == login.domain || host.hostname.endsWith("." + login.domain);
+                host.hostname == login.domain || // host matches path component exactly
+                (login.domain.includes(".") && // path component is not a single level (e.g. com, net, local)...
+                    host.hostname.endsWith("." + login.domain)); // ...and the host ends with that path component
             if (domainInfo && domainInfo.port && domainInfo.port !== host.port) {
                 login.inCurrentHost = false;
             }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,7 +59,7 @@ function pathToInfo(path, currentHost) {
 function prepareLogins(files, settings) {
     const logins = [];
     let index = 0;
-    let host = BrowserpassURL.parseHost(settings.host);
+    let origin = new BrowserpassURL(settings.origin);
 
     for (let storeId in files) {
         for (let key in files[storeId]) {
@@ -72,7 +72,7 @@ function prepareLogins(files, settings) {
             };
 
             // extract url info from path
-            let pathInfo = pathToInfo(storeId + "/" + login.login, host);
+            let pathInfo = pathToInfo(storeId + "/" + login.login, origin);
             if (pathInfo) {
                 // set assumed host
                 login.host = pathInfo.port
@@ -80,20 +80,20 @@ function prepareLogins(files, settings) {
                     : pathInfo.hostname;
 
                 // check whether extracted path info matches the current origin
-                login.inCurrentHost = host.hostname === pathInfo.hostname;
+                login.inCurrentHost = origin.hostname === pathInfo.hostname;
 
                 // check whether the current origin is subordinate to extracted path info, meaning:
                 //  - that the path info is not a single level domain (e.g. com, net, local)
                 //  - and that the current origin is a subdomain of that path info
                 if (
                     pathInfo.hostname.includes(".") &&
-                    host.hostname.endsWith(`.${pathInfo.hostname}`)
+                    origin.hostname.endsWith(`.${pathInfo.hostname}`)
                 ) {
                     login.inCurrentHost = true;
                 }
 
                 // filter out entries with a non-matching port
-                if (pathInfo.port && pathInfo.port !== host.port) {
+                if (pathInfo.port && pathInfo.port !== origin.port) {
                     login.inCurrentHost = false;
                 }
             } else {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -103,7 +103,7 @@ function prepareLogins(files, settings) {
 
             // update recent counter
             login.recent =
-                settings.recent[sha1(settings.host + sha1(login.store.id + sha1(login.login)))];
+                settings.recent[sha1(settings.origin + sha1(login.store.id + sha1(login.login)))];
             if (!login.recent) {
                 login.recent = {
                     when: 0,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,7 @@
 const FuzzySort = require("fuzzysort");
 const sha1 = require("sha1");
 const ignore = require("ignore");
-const BrowserPassURL = require("@browserpass/url");
+const BrowserpassURL = require("@browserpass/url");
 
 module.exports = {
     pathToDomainInfo,
@@ -30,7 +30,7 @@ function pathToDomainInfo(path, currentHost) {
         if (parts[key].indexOf("@") >= 0) {
             continue;
         }
-        var info = BrowserPassURL.parseHost(parts[key]);
+        var info = BrowserpassURL.parseHost(parts[key]);
 
         // Part is considered to be a domain component in one of the following cases:
         // - it is a valid domain with well-known TLD (github.com, login.github.com)
@@ -60,7 +60,7 @@ function pathToDomainInfo(path, currentHost) {
 function prepareLogins(files, settings) {
     const logins = [];
     let index = 0;
-    let host = BrowserPassURL.parseHost(settings.host);
+    let host = BrowserpassURL.parseHost(settings.host);
 
     for (let storeId in files) {
         for (let key in files[storeId]) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,9 +2,9 @@
 "use strict";
 
 const FuzzySort = require("fuzzysort");
-const TldJS = require("tldjs");
 const sha1 = require("sha1");
 const ignore = require("ignore");
+const BrowserPassURL = require("@browserpass/url");
 
 module.exports = {
     pathToDomain,
@@ -30,18 +30,18 @@ function pathToDomain(path, currentHost) {
         if (parts[key].indexOf("@") >= 0) {
             continue;
         }
-        var t = TldJS.parse(parts[key]);
+        var info = BrowserPassURL.parseHostname(parts[key]);
 
         // Part is considered to be a domain component in one of the following cases:
         // - it is a valid domain with well-known TLD (github.com, login.github.com)
-        // - it is a valid domain with unknown TLD but the current host is it's subdomain (login.pi.hole)
-        // - it is or isnt a valid domain but the current host matches it EXACTLY (localhost, pi.hole)
+        // - it is or isn't a valid domain with unknown TLD but the current host is its subdomain (login.pi.hole)
+        // - it is or isn't a valid domain but the current host matches it EXACTLY (localhost, pi.hole)
         if (
-            t.isValid &&
-            ((t.domain !== null && (t.tldExists || currentHost.endsWith(`.${t.hostname}`))) ||
-                currentHost === t.hostname)
+            info.validDomain ||
+            currentHost.endsWith(`.${info.hostname}`) ||
+            currentHost === info.hostname
         ) {
-            return t.hostname;
+            return info.hostname;
         }
     }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -73,10 +73,10 @@ function prepareLogins(files, settings) {
             };
             let domainInfo = pathToDomainInfo(storeId + "/" + login.login, settings.host);
             login.domain = domainInfo ? domainInfo.hostname : null;
-            login.inCurrentDomain =
+            login.inCurrentHost =
                 host.hostname == login.domain || host.hostname.endsWith("." + login.domain);
             if (domainInfo && domainInfo.port && domainInfo.port !== host.port) {
-                login.inCurrentDomain = false;
+                login.inCurrentHost = false;
             }
             login.recent =
                 settings.recent[sha1(settings.host + sha1(login.store.id + sha1(login.login)))];
@@ -129,7 +129,7 @@ function filterSortLogins(logins, searchQuery, currentDomainOnly) {
             return false;
         });
         var remainingInCurrentDomain = candidates.filter(
-            login => login.inCurrentDomain && !login.recent.count
+            login => login.inCurrentHost && !login.recent.count
         );
         candidates = recent.concat(remainingInCurrentDomain);
     }

--- a/src/package.json
+++ b/src/package.json
@@ -15,14 +15,14 @@
         }
     ],
     "dependencies": {
+        "@browserpass/url": "^1.1.0",
         "chrome-extension-async": "^3.3.2",
         "fuzzysort": "^1.1.4",
         "idb": "^4.0.3",
         "ignore": "^5.1.4",
         "mithril": "^1.1.0",
         "moment": "^2.24.0",
-        "sha1": "^1.1.1",
-        "tldjs": "^2.3.0"
+        "sha1": "^1.1.1"
     },
     "devDependencies": {
         "browserify": "^16.2.3",

--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
         }
     ],
     "dependencies": {
-        "@browserpass/url": "^1.1.0",
+        "@browserpass/url": "^1.1.2",
         "chrome-extension-async": "^3.3.2",
         "fuzzysort": "^1.1.4",
         "idb": "^4.0.3",

--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
         }
     ],
     "dependencies": {
-        "@browserpass/url": "^1.1.2",
+        "@browserpass/url": "^1.1.3",
         "chrome-extension-async": "^3.3.2",
         "fuzzysort": "^1.1.4",
         "idb": "^4.0.3",

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -47,7 +47,7 @@ async function run() {
             throw new Error(settings.hostError.params.message);
         }
 
-        if (typeof settings.host === "undefined") {
+        if (typeof settings.origin === "undefined") {
             throw new Error("Unable to retrieve current tab information");
         }
 

--- a/src/popup/searchinterface.js
+++ b/src/popup/searchinterface.js
@@ -29,6 +29,7 @@ function SearchInterface(popup) {
  */
 function view(ctl, params) {
     var self = this;
+    var host = new URL(this.popup.settings.origin).host;
     return m(
         "form.part.search",
         {
@@ -59,7 +60,7 @@ function view(ctl, params) {
         [
             this.popup.currentDomainOnly
                 ? m("div.hint.badge", [
-                      this.popup.settings.host,
+                      host,
                       m("div.remove-hint", {
                           onclick: function(e) {
                               var target = document.querySelector(

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@browserpass/url@^1.1.0":
+"@browserpass/url@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.2.tgz#f12b67861ab728011a40e52902e86c67bfeacae4"
   integrity sha512-H0WA6nfd3CnlLXa0cExMb7iOoJYqfjLkitXkK4EMMiy/DD73PO8TONGQFmAIqSaoJ+X5SowOOZwGbm0nol/NKA==

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@browserpass/url@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.2.tgz#f12b67861ab728011a40e52902e86c67bfeacae4"
-  integrity sha512-H0WA6nfd3CnlLXa0cExMb7iOoJYqfjLkitXkK4EMMiy/DD73PO8TONGQFmAIqSaoJ+X5SowOOZwGbm0nol/NKA==
+"@browserpass/url@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.3.tgz#8b94896198e7032b80c7d82e836d59e42b769669"
+  integrity sha512-XWhYNZo0BGcyFxkum8g1DeUkFw9QyqcaRTOEinyPSpIubh+aL2VQxbdItitVtS5qkkowqaA5Xt1H2pAqu8ic8w==
   dependencies:
     punycode "^2.1.1"
 

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@browserpass/url@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.1.tgz#5307f503bcc6f42447ee7fa0ad51d7d80b6f00f9"
-  integrity sha512-yakyORkkcasqZ0Rz3oCNMCVCNxYcTByksUf8YJVLNS7mNZwUuYA1rsCoka914UQr7d3ThUPTGAsgKvOkHYRKmg==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.2.tgz#f12b67861ab728011a40e52902e86c67bfeacae4"
+  integrity sha512-H0WA6nfd3CnlLXa0cExMb7iOoJYqfjLkitXkK4EMMiy/DD73PO8TONGQFmAIqSaoJ+X5SowOOZwGbm0nol/NKA==
   dependencies:
     punycode "^2.1.1"
 

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@browserpass/url@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.1.tgz#5307f503bcc6f42447ee7fa0ad51d7d80b6f00f9"
+  integrity sha512-yakyORkkcasqZ0Rz3oCNMCVCNxYcTByksUf8YJVLNS7mNZwUuYA1rsCoka914UQr7d3ThUPTGAsgKvOkHYRKmg==
+  dependencies:
+    punycode "^2.1.1"
+
 JSONStream@^1.0.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -1089,7 +1096,7 @@ punycode@^1.3.2, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -1346,13 +1353,6 @@ timers-browserify@^1.0.1:
   integrity sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=
   dependencies:
     process "~0.11.0"
-
-tldjs@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tldjs/-/tldjs-2.3.1.tgz#cf09c3eb5d7403a9e214b7d65f3cf9651c0ab039"
-  integrity sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==
-  dependencies:
-    punycode "^1.4.1"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## What
 * Replace tldjs with @browserpass/url
 * Only show logins with a port for origins with a matching port

## Why
 * Because tldjs is no longer maintained (#164)
 * Because ports are part of the origin

@maximbaz Do you prefer this approach for port matching, or the one in #178? I added it here because it was easy to do both these tasks at the same time, but if another approach is desired I can adjust the PR.