### PR TITLE
Autofill: re-set the field value if necessary

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -409,12 +409,20 @@
         }
 
         // Set the field value
+        let initialValue = el.value || el.getAttribute("value");
         el.setAttribute("value", value);
         el.value = value;
 
         // Send the keyboard events again indicating that value modification has finished (no associated keycode)
         for (let eventName of ["keydown", "keypress", "keyup", "input", "change"]) {
             el.dispatchEvent(new Event(eventName, { bubbles: true }));
+        }
+
+        // re-set value if unchanged after firing post-fill events
+        // (in case of sabotage by the site's own event handlers)
+        if ((el.value || el.getAttribute("value")) === initialValue) {
+            el.setAttribute("value", value);
+            el.value = value;
         }
 
         // Finally unfocus the element


### PR DESCRIPTION
## What

If the site's own event handlers have sabotaged the value after firing the post-fill events (i.e. if the field has returned to its initialvalue), then set it a second time without firing the events.

## Why

To resolve login problems on https://www.epicgames.com/id/login (see [#62](https://github.com/browserpass/browserpass-extension/issues/62#issuecomment-543741444)).