### PR TITLE
Make Ctrl+C copy username if username button is focused

### DIFF
--- a/src/popup/interface.js
+++ b/src/popup/interface.js
@@ -206,7 +206,11 @@ function keyHandler(e) {
             break;
         case "KeyC":
             if (e.ctrlKey) {
-                this.doAction(e.shiftKey ? "copyUsername" : "copyPassword");
+                if (e.shiftKey || document.activeElement.classList.contains("copy-user")) {
+                    this.doAction("copyUsername");
+                } else {
+                    this.doAction("copyPassword");
+                }
             }
             break;
         case "KeyG":


### PR DESCRIPTION
## What

If the username button is currently focused, <kbd>CTRL+C</kbd> will copy the username, not the password.

![image](https://user-images.githubusercontent.com/121486/67149735-7edb4580-f30b-11e9-8d06-88b0ff9b61f0.png)

## Why

Because the obvious behavior, when the username button is selected, is to copy the username.