### PR TITLE
Allow `data:` scheme for images in CSP

### DIFF
--- a/src/manifest-chromium.json
+++ b/src/manifest-chromium.json
@@ -40,7 +40,7 @@
         "http://*/*",
         "https://*/*"
     ],
-    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'",
+    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self'",
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -37,7 +37,7 @@
         "http://*/*",
         "https://*/*"
     ],
-    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'",
+    "content_security_policy": "default-src 'none'; font-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self'",
     "applications": {
         "gecko": {
             "id": "browserpass@maximbaz.com",


### PR DESCRIPTION
Per https://stackoverflow.com/a/18449556 it seems we need to whitelist `data:` scheme.

This bug appeared because light theme PR for the first time introduced select box in the options screen, and browser styles arrow in the select box using an image constructed with `data:`.

I think there's no harm security-wise in allowing `data:` scheme, what do you think?

Fixes #184 