### PR TITLE
Improve autosubmit via Chromium's debugger

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -327,14 +327,17 @@ async function dispatchFocusOrSubmit(settings, request, allFrames, allowForeign)
         for (let frame of perFrameResults) {
             if (frame.needPressEnter) {
                 chrome.debugger.attach({ tabId: settings.tab.id }, "1.2");
-                for (let type of ["keyDown", "keyUp"]) {
+                for (let type of ["keyDown", "char", "keyUp"]) {
                     chrome.debugger.sendCommand(
                         { tabId: settings.tab.id },
                         "Input.dispatchKeyEvent",
                         {
                             type: type,
+                            key: "Enter",
                             windowsVirtualKeyCode: 13,
-                            nativeVirtualKeyCode: 13
+                            nativeVirtualKeyCode: 13,
+                            unmodifiedText: "\r",
+                            text: "\r"
                         }
                     );
                 }


### PR DESCRIPTION
Found this somewhere on the Internet, to my surprise this set of extra properties makes `Enter` simulation... better. Also although not required, I'm now sending another "char" event because that's what that example did - just in case :).

This fixes autosubmit in Chromium on https://grabr.io/

----

@erayd I intentionally kept the "Detached while handling command" errors, the way to get rid of them is to `await` all `chrome.debugger.XXX` calls, but then it becomes very visible that Browserpass enables and disables debugger (like you can see this top bar appearing). It works every time without `await`, and it's completely invisible to the user that we temporarily enable debugger, so I think it's more preferable to keep it this way. What do you think? :)