### PR TITLE
Truncate maxlength= fields

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -411,6 +411,12 @@
             el.dispatchEvent(new Event(eventName, { bubbles: true }));
         }
 
+        // truncate the value if required by the field
+        let maxLength = el.getAttribute("maxlength");
+        if (maxLength) {
+            value = value.substr(0, maxLength);
+        }
+
         // Set the field value
         let initialValue = el.value || el.getAttribute("value");
         el.setAttribute("value", value);

--- a/src/inject.js
+++ b/src/inject.js
@@ -412,9 +412,8 @@
         }
 
         // truncate the value if required by the field
-        let maxLength = el.getAttribute("maxlength");
-        if (maxLength) {
-            value = value.substr(0, maxLength);
+        if (el.maxLength > 0) {
+            value = value.substr(0, el.maxLength);
         }
 
         // Set the field value


### PR DESCRIPTION
## What

When filling fields, if a field has `maxlength=` defined, truncate the value to that length prior to filling.

## Why

Because if the value is not truncated, then Browserpass fills the entire value, which deviates from the behavior when the user types the password manually or pastes it (in which case the browser will truncate the value as it's entered).