### PR TITLE
Resolve "null is not a valid URL" errors caused by a URL parsing bug in Firefox

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -139,7 +139,7 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
 
         try {
             const tab = await chrome.tabs.get(tabId);
-            badgeCache.settings.origin = new URL(tab.url).origin;
+            badgeCache.settings.origin = tab.url && new BrowserpassURL(tab.url).origin;
         } catch (e) {
             throw new Error(`Unable to determine domain of the tab with id ${tabId}`);
         }
@@ -590,7 +590,10 @@ async function getFullSettings() {
         let originInfo = new BrowserpassURL(settings.tab.url);
         settings.host = originInfo.host; // TODO remove this after OTP extension is migrated
         settings.origin = originInfo.origin;
-    } catch (e) {}
+    } catch (e) {
+        settings.host = null;
+        settings.origin = null;
+    }
 
     return settings;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,7 +59,7 @@ function pathToInfo(path, currentHost) {
 function prepareLogins(files, settings) {
     const logins = [];
     let index = 0;
-    let origin = new BrowserpassURL(settings.origin);
+    let origin = settings.origin && new BrowserpassURL(settings.origin);
 
     for (let storeId in files) {
         for (let key in files[storeId]) {
@@ -72,7 +72,7 @@ function prepareLogins(files, settings) {
             };
 
             // extract url info from path
-            let pathInfo = pathToInfo(storeId + "/" + login.login, origin);
+            let pathInfo = origin && pathToInfo(storeId + "/" + login.login, origin);
             if (pathInfo) {
                 // set assumed host
                 login.host = pathInfo.port

--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
         }
     ],
     "dependencies": {
-        "@browserpass/url": "^1.1.3",
+        "@browserpass/url": "^1.1.5",
         "chrome-extension-async": "^3.3.2",
         "fuzzysort": "^1.1.4",
         "idb": "^4.0.3",

--- a/src/popup/searchinterface.js
+++ b/src/popup/searchinterface.js
@@ -29,7 +29,7 @@ function SearchInterface(popup) {
  */
 function view(ctl, params) {
     var self = this;
-    var host = new URL(this.popup.settings.origin).host;
+    var host = this.popup.settings.origin && new URL(this.popup.settings.origin).host;
     return m(
         "form.part.search",
         {

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@browserpass/url@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.3.tgz#8b94896198e7032b80c7d82e836d59e42b769669"
-  integrity sha512-XWhYNZo0BGcyFxkum8g1DeUkFw9QyqcaRTOEinyPSpIubh+aL2VQxbdItitVtS5qkkowqaA5Xt1H2pAqu8ic8w==
+"@browserpass/url@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@browserpass/url/-/url-1.1.5.tgz#5b94c13421a69fc58bcb9b9f214ad6dd8b544319"
+  integrity sha512-er+AQEOXXgEfJVp38SCVvV3noAvKs+07o8+cGXyexTV7AVpkUSm6jdtFBFn2ijxjomKEmdBJZ8pVajs2Nhm1GA==
   dependencies:
     punycode "^2.1.1"
 


### PR DESCRIPTION
## What

 * Work around parsing issue with URLs in Firefox
 * Adjust code to expect nulls in the origin field

Fixes #191.

## Why

Because Firefox is annoyingly broken, again, and somehow thinks providing `"null"` instead of `null` is reasonable.