### PR TITLE
Use binary package name for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to install Browserpass correctly, you have to install two of its compon
 -   Browser extension for Chromium-based browsers (choose one of the options):
     -   Install using a package manager for your OS (which will provide auto-update and keep extension in sync with native host app):
         -   Arch Linux: [browserpass-chromium](https://www.archlinux.org/packages/community/any/browserpass-chromium/), [browserpass-chrome](https://aur.archlinux.org/packages/browserpass-chrome/)
-        -   Debian: [browserpass](https://packages.debian.org/source/sid/browserpass) includes Chromium extension
+        -   Debian: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass) includes Chromium extension
     -   Install the extension from [Chrome Web Store](https://chrome.google.com/webstore/detail/browserpass-ce/naepdomgkenhinolocfifgehidddafch) (which will provide auto-updates)
     -   Download `browserpass-webstore.crx` from the latest release and drag'n'drop it into `chrome://extensions`
         -   This extension has the same ID as the one in Chrome Web Store, so when a new version will appear in Web Store, it will auto-update! Use if you want to be on latest and greatest version.
@@ -63,7 +63,7 @@ In order to install Browserpass correctly, you have to install two of its compon
 -   Browser extension for Firefox-based browsers (choose one of the options):
     -   Install using a package manager for your OS (which will provide auto-update and keep extension in sync with native host app):
         -   Arch Linux: [browserpass-firefox](https://www.archlinux.org/packages/community/any/browserpass-firefox/)
-        -   Debian: [browserpass](https://packages.debian.org/source/sid/browserpass) includes Firefox extension
+        -   Debian: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass) includes Firefox extension
     -   Install the extension from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/browserpass-ce/) (which will provide auto-updates)
     -   Download `browserpass-firefox.zip` from the latest release, unarchive and use `Load Temporary Add-on` on `about:debugging#addons` (remember the extension will be removed after browser is closed!).
 


### PR DESCRIPTION
It is more useful for users to refer to the _binary package_ `webext-browserpass` instead of the _source package name_  for the Debian distribution, as the binary packages are the ones which can be installed by `apt`.

This proposed modification reflects this in the README.
This pull request is similar to https://github.com/browserpass/browserpass-native/pull/96 for browserpass-native.