### PR TITLE
Add "email" to list of username field keys in parseFields

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -909,7 +909,7 @@ async function parseFields(settings, login) {
     // parse lines
     login.fields = {
         secret: ["secret", "password", "pass"],
-        login: ["login", "username", "user"],
+        login: ["login", "username", "user", "email", "e-mail"],
         openid: ["openid"],
         otp: ["otp", "totp", "hotp"],
         url: ["url", "uri", "website", "site", "link", "launch"]


### PR DESCRIPTION
Hey guys. I just made this small change for my personal setup and figured it might be helpful for a wider range of users. This PR just adds `email` and `e-mail` as possible fields to represent the username for a given site.

It seems to me like the use of some sort of `email: me@example.com` line would be fairly common in people's password stores. A lot of my accounts have no `username` line, just an email, but browserpass doesn't handle that situation correctly, instead defaulting to the filename (which is often the URL, not the username/email).

One solution is to instead use `login`/`user`/`username` instead of `email` as the key in those files, but I think the distinction between username and email is important and useful (for clarity, if nothing else).

Not sure how this change might affect autofill, like whether some login forms that accept either only email or only username will be treated correctly (but in my experience, most sites allow you to enter either to sign in). Maybe the extension should draw a distinction between username/email and treat them differently?

I'm willing to help with a different solution if mine is a bit too hacky