### PR TITLE
Allow hiding badge counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The list of available options:
 | --------------------------------------------------------------- | ------------------------------------------------------------- |
 | Automatically submit forms after filling (aka `autoSubmit`)     | Make Browserpass automatically submit the login form for you  |
 | Enable support for OTP tokens (aka `enableOTP`)                 | Generate TOTP codes if a TOTP seed is found in the pass entry |
+| Hide badge counter on the toolbar icon (aka `hideBadge`)        | Do not show badge with number of matching password entries    |
 | Default username (aka `username`)                               | Username to use when it's not defined in the password file    |
 | Custom gpg binary (aka `gpgPath`)                               | Path to a custom `gpg` binary to use                          |
 | Custom store locations                                          | List of password stores to use                                |
@@ -242,6 +243,7 @@ Browserpass allows configuring certain settings in different places places using
     - `autoSubmit`
 1. Options defined in `.browserpass.json` file located in the root of a password store:
     - `autoSubmit`
+    - `hideBadge`
     - `enableOTP`
     - `gpgPath`
     - `username`
@@ -251,6 +253,7 @@ Browserpass allows configuring certain settings in different places places using
 1. Options defined in browser extension options:
     - Automatically submit forms after filling (aka `autoSubmit`)
     - Enable support for OTP tokens (aka `enableOTP`)
+    - Hide badge counter on the toolbar icon (aka `hideBadge`)
     - Default username (aka `username`)
     - Custom gpg binary (aka `gpgPath`)
     - Custom store locations

--- a/src/background.js
+++ b/src/background.js
@@ -19,6 +19,7 @@ var defaultSettings = {
     username: null,
     theme: "auto",
     enableOTP: false,
+    hideBadge: false,
     caps: {
         save: false,
         delete: false,
@@ -120,15 +121,19 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
         if (forceRefresh || Date.now() > badgeCache.expires) {
             badgeCache.isRefreshing = true;
 
+            let files = [];
             let settings = await getFullSettings();
-            let response = await hostAction(settings, "list");
-            if (response.status != "ok") {
-                throw new Error(JSON.stringify(response));
+            if (!settings.hideBadge) {
+                let response = await hostAction(settings, "list");
+                if (response.status != "ok") {
+                    throw new Error(JSON.stringify(response));
+                }
+                files = response.data.files;
             }
 
             const CACHE_TTL_MS = 60 * 1000;
             badgeCache = {
-                files: response.data.files,
+                files: files,
                 settings: settings,
                 expires: Date.now() + CACHE_TTL_MS,
                 isRefreshing: false,
@@ -156,6 +161,7 @@ async function updateMatchingPasswordsCount(tabId, forceRefresh = false) {
             tabId: tabId,
         });
     } catch (e) {
+        badgeCache.isRefreshing = false;
         console.log(e);
     }
 }
@@ -1146,6 +1152,9 @@ async function saveSettings(settings) {
             localStorage.setItem(key, JSON.stringify(settingsToSave[key]));
         }
     }
+
+    // refresh in case user has just toggled showing badge counter
+    updateMatchingPasswordsCount(settings.tab.id, true);
 }
 
 /**

--- a/src/options/interface.js
+++ b/src/options/interface.js
@@ -58,6 +58,7 @@ function view(ctl, params) {
     nodes.push(
         createCheckbox.call(this, "enableOTP", "Enable support for OTP tokens (not recommended)")
     );
+    nodes.push(createCheckbox.call(this, "hideBadge", "Hide badge counter on the toolbar icon"));
     nodes.push(createInput.call(this, "username", "Default username", "john.smith"));
     nodes.push(createInput.call(this, "gpgPath", "Custom gpg binary", "/path/to/gpg"));
 


### PR DESCRIPTION
Note this implementation doesn't just prevent entering `updateMatchingPasswordsCount()` function (as I personally initially expected), but only prevents doing what is hopefully the most expensive computation: getting a huge array of files and processing them.

This way, when a user toggles badge option we would refresh the badge instantly, and also if a user puts `hideBadge` in their `.browserpass.json` we would detect it within a minute. This also means that tab update handler still executes and it still refreshes settings every minute.

I would be really interested to know if this solves #224, @elprans if you could try this PR it would be much appreciated.

@erayd what do you think in general?

Fixes #224 
Fixes #103
Fixes #342 
Fixes #348 