### PR TITLE
Honor store-specific enableOTP setting

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -743,7 +743,7 @@ async function handleMessage(settings, message, sendResponse) {
             }
             break;
         case "copyOTP":
-            if (settings.enableOTP) {
+            if (settings.enableOTP || settings.stores[message.login.store.id].settings.enableOTP) {
                 try {
                     if (!message.login.fields.otp) {
                         throw new Exception("No OTP seed available");
@@ -982,7 +982,10 @@ async function parseFields(settings, login) {
     }
 
     // preprocess otp
-    if (settings.enableOTP && login.fields.hasOwnProperty("otp")) {
+    if (
+        (settings.enableOTP || settings.stores[login.store.id].settings.enableOTP) &&
+        login.fields.hasOwnProperty("otp")
+    ) {
         if (login.fields.otp.match(/^otpauth:\/\/.+/i)) {
             // attempt to parse otp data as URI
             try {

--- a/src/background.js
+++ b/src/background.js
@@ -743,7 +743,7 @@ async function handleMessage(settings, message, sendResponse) {
             }
             break;
         case "copyOTP":
-            if (settings.enableOTP || settings.stores[message.login.store.id].settings.enableOTP) {
+            if (getSetting("enableOTP", message.login, settings)) {
                 try {
                     if (!message.login.fields.otp) {
                         throw new Exception("No OTP seed available");
@@ -815,7 +815,7 @@ async function handleMessage(settings, message, sendResponse) {
 
                 // copy OTP token after fill
                 if (
-                    settings.enableOTP &&
+                    getSetting("enableOTP", message.login, settings) &&
                     typeof message.login !== "undefined" &&
                     message.login.fields.hasOwnProperty("otp")
                 ) {
@@ -982,10 +982,7 @@ async function parseFields(settings, login) {
     }
 
     // preprocess otp
-    if (
-        (settings.enableOTP || settings.stores[login.store.id].settings.enableOTP) &&
-        login.fields.hasOwnProperty("otp")
-    ) {
+    if (getSetting("enableOTP", login, settings) && login.fields.hasOwnProperty("otp")) {
         if (login.fields.otp.match(/^otpauth:\/\/.+/i)) {
             // attempt to parse otp data as URI
             try {

--- a/src/popup/detailsInterface.js
+++ b/src/popup/detailsInterface.js
@@ -103,7 +103,8 @@ function view(ctl, params) {
             ]),
             (() => {
                 if (
-                    this.settings.enableOTP &&
+                    (this.settings.enableOTP ||
+                        this.settings.stores[login.store.id].settings.enableOTP) &&
                     login.fields.otp &&
                     login.fields.otp.params.type === "totp"
                 ) {

--- a/src/popup/detailsInterface.js
+++ b/src/popup/detailsInterface.js
@@ -103,8 +103,7 @@ function view(ctl, params) {
             ]),
             (() => {
                 if (
-                    (this.settings.enableOTP ||
-                        this.settings.stores[login.store.id].settings.enableOTP) &&
+                    (this.settings.enableOTP || login.store.settings.enableOTP) &&
                     login.fields.otp &&
                     login.fields.otp.params.type === "totp"
                 ) {


### PR DESCRIPTION
The [Options] allow for the `enableOTP` feature to be specified within
the `.browserpass.json`, but the feature is not enabled when the
option is specified within `.browserpass.json` and not globally.

This was because the check for the setting was only looking for the
global setting - `settings.enableOTP` and did not check for the
`.browserpass.json` setting ( `settings.stores[*].settings.enableOTP` ).

This changeset fixes that issue and properly honors the `enableOTP`
setting specified within `.browserpass.json` with or without the
global `enableOTP` setting.

[Options]: https://github.com/browserpass/browserpass-extension#options
