### PR TITLE
fix `enableOTP` handling to match docs: prioritize store, then extension config

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -450,7 +450,7 @@ async function fillFields(settings, login, fields) {
     // build focus or submit request
     let focusOrSubmitRequest = {
         origin: new BrowserpassURL(settings.tab.url).origin,
-        autoSubmit: getSetting("autoSubmit", login, settings),
+        autoSubmit: helpers.getSetting("autoSubmit", login, settings),
         filledFields: filledFields,
     };
 
@@ -559,25 +559,6 @@ async function getFullSettings() {
     } catch (e) {}
 
     return settings;
-}
-
-/**
- * Get most relevant setting value
- *
- * @param string key      Setting key
- * @param object login    Login object
- * @param object settings Settings object
- * @return object Setting value
- */
-function getSetting(key, login, settings) {
-    if (typeof login.settings[key] !== "undefined") {
-        return login.settings[key];
-    }
-    if (typeof settings.stores[login.store.id].settings[key] !== "undefined") {
-        return settings.stores[login.store.id].settings[key];
-    }
-
-    return settings[key];
 }
 
 /**
@@ -968,7 +949,7 @@ async function parseFields(settings, login) {
             if (key === "secret" && lines.length) {
                 login.fields.secret = lines[0];
             } else if (key === "login") {
-                const defaultUsername = getSetting("username", login, settings);
+                const defaultUsername = helpers.getSetting("username", login, settings);
                 login.fields[key] = defaultUsername || login.login.match(/([^\/]+)$/)[1];
             } else {
                 delete login.fields[key];

--- a/src/background.js
+++ b/src/background.js
@@ -724,7 +724,7 @@ async function handleMessage(settings, message, sendResponse) {
             }
             break;
         case "copyOTP":
-            if (settings.enableOTP) {
+            if (helpers.getSetting("enableOTP", message.login, settings)) {
                 try {
                     if (!message.login.fields.otp) {
                         throw new Exception("No OTP seed available");
@@ -796,8 +796,8 @@ async function handleMessage(settings, message, sendResponse) {
 
                 // copy OTP token after fill
                 if (
-                    settings.enableOTP &&
                     typeof message.login !== "undefined" &&
+                    helpers.getSetting("enableOTP", message.login, settings) &&
                     message.login.fields.hasOwnProperty("otp")
                 ) {
                     copyToClipboard(helpers.makeTOTP(message.login.fields.otp.params));
@@ -963,7 +963,7 @@ async function parseFields(settings, login) {
     }
 
     // preprocess otp
-    if (settings.enableOTP && login.fields.hasOwnProperty("otp")) {
+    if (helpers.getSetting("enableOTP", login, settings) && login.fields.hasOwnProperty("otp")) {
         if (login.fields.otp.match(/^otpauth:\/\/.+/i)) {
             // attempt to parse otp data as URI
             try {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,11 +11,31 @@ const BrowserpassURL = require("@browserpass/url");
 module.exports = {
     prepareLogins,
     filterSortLogins,
+    getSetting,
     ignoreFiles,
     makeTOTP,
 };
 
 //----------------------------------- Function definitions ----------------------------------//
+
+/**
+ * Get most relevant setting value
+ *
+ * @param string key      Setting key
+ * @param object login    Login object
+ * @param object settings Settings object
+ * @return object Setting value
+ */
+function getSetting(key, login, settings) {
+    if (typeof login.settings[key] !== "undefined") {
+        return login.settings[key];
+    }
+    if (typeof settings.stores[login.store.id].settings[key] !== "undefined") {
+        return settings.stores[login.store.id].settings[key];
+    }
+
+    return settings[key];
+}
 
 /**
  * Get the deepest available domain component of a path

--- a/src/popup/detailsInterface.js
+++ b/src/popup/detailsInterface.js
@@ -103,7 +103,7 @@ function view(ctl, params) {
             ]),
             (() => {
                 if (
-                    this.settings.enableOTP &&
+                    helpers.getSetting("enableOTP", login, this.settings) &&
                     login.fields.otp &&
                     login.fields.otp.params.type === "totp"
                 ) {


### PR DESCRIPTION
the README.md says:

> Browserpass allows configuring certain settings in different places places using the following priority, highest first:
> 
> 1. Options defined in specific `*.gpg` files, only apply to these password entries:
>     - `autoSubmit`
> 2. Options defined in `.browserpass.json` file located in the root of a password store:
>     - `autoSubmit`
>     - **`enableOTP`**
>     ...
> 3. Options defined in browser extension options:
>     - Automatically submit forms after filling (aka `autoSubmit`)
>     - Enable support for OTP tokens (aka **`enableOTP`**)


this makes it sound like one should be able to set `enableOTP = true` inside a store's config and leave it unset at the extension level, which sounds intuitive. but when i try that on master i'm not shown any token. unless i've missed something, the code only attempts to read this from the extension-level settings. this PR fixes that to match the behavior of the readme.

tested manually:
- [x] check OTP box in browser config, omit the field in `.browserpass.json` -> shows token
- [x] check OTP box in browser config, `"enableOTP": false` in store -> no token
- [x] leave OTP box unchecked in browser config, set `"enableOTP": true` in the store level -> shows token
- [x] leave OTP box unchecked in browser config, omit `enableOTP` from the store config, set `enableOTP: true` in a secret -> no token

i'm a novice JS dev, so if i'm breaking idioms with my approach here don't hold back in setting me straight 😉