### PR TITLE
pass the unmodified login path to the native component instead of assuming .gpg

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -870,7 +870,7 @@ function hostAction(settings, action, params = {}) {
 async function parseFields(settings, login) {
     var response = await hostAction(settings, "fetch", {
         storeId: login.store.id,
-        file: login.login + ".gpg",
+        file: login.loginPath,
     });
     if (response.status != "ok") {
         throw new Error(JSON.stringify(response)); // TODO handle host error

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,10 +87,14 @@ function prepareLogins(files, settings) {
     for (let storeId in files) {
         for (let key in files[storeId]) {
             // set login fields
+            const loginPath = files[storeId][key];
+            // remove the file-type extension
+            const loginName = loginPath.replace(/\.[^.]+$/u, "");
             const login = {
                 index: index++,
                 store: settings.stores[storeId],
-                login: files[storeId][key].replace(/\.gpg$/i, ""),
+                login: loginName,
+                loginPath: loginPath,
                 allowFill: true,
             };
 


### PR DESCRIPTION
this is in support of
<https://github.com/browserpass/browserpass-native/issues/127>.

this has immediate benefit for anyone using the patches shared in that PR today. without this, browserpass doesn't recognize `github.com.age` as a default key for `https://github.com`, because it fails the substring match. by stripping the extension -- whatever it is -- both `github.com.gpg` and `github.com.age` are recognized as keys for their intended domain.