### PR TITLE
Add automatic light/dark theme setting

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,7 @@ var defaultSettings = {
     stores: {},
     foreignFills: {},
     username: null,
-    theme: "dark",
+    theme: "auto",
     enableOTP: false,
     caps: {
         save: false,

--- a/src/options/interface.js
+++ b/src/options/interface.js
@@ -64,9 +64,9 @@ function view(ctl, params) {
     nodes.push(m("h3", "Theme"));
     nodes.push(
         createDropdown.call(this, "theme", [
+            m("option", { value: "auto" }, "Auto"),
             m("option", { value: "dark" }, "Dark"),
             m("option", { value: "light" }, "Light"),
-            m("option", { value: "auto" }, "Auto"),
         ])
     );
 

--- a/src/options/interface.js
+++ b/src/options/interface.js
@@ -66,6 +66,7 @@ function view(ctl, params) {
         createDropdown.call(this, "theme", [
             m("option", { value: "dark" }, "Dark"),
             m("option", { value: "light" }, "Light"),
+            m("option", { value: "auto" }, "Auto"),
         ])
     );
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -43,6 +43,17 @@ async function run() {
         root.classList.remove("colors-dark");
         root.classList.add(`colors-${settings.theme}`);
 
+        if (settings.theme == "auto") {
+            const darkThemeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+            updateTheme(root, darkThemeMediaQuery.matches);
+
+            darkThemeMediaQuery.addEventListener("change", (e) => {
+                updateTheme(root, e.matches);
+            });
+        } else {
+            updateTheme(root, settings.theme == "dark");
+        }
+
         // get list of logins
         logins = await Login.prototype.getAll(settings);
         layout.setSessionSettings(settings);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -43,16 +43,15 @@ async function run() {
         root.classList.remove("colors-dark");
         root.classList.add(`colors-${settings.theme}`);
 
-        if (settings.theme == "auto") {
-            const darkThemeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-            updateTheme(root, darkThemeMediaQuery.matches);
-
-            darkThemeMediaQuery.addEventListener("change", (e) => {
-                updateTheme(root, e.matches);
-            });
-        } else {
-            updateTheme(root, settings.theme == "dark");
-        }
+        // set theme
+        const theme =
+            settings.theme === "auto"
+                ? window.matchMedia("(prefers-color-scheme: dark)").matches
+                    ? "dark"
+                    : "light"
+                : settings.theme;
+        root.classList.remove("colors-light", "colors-dark");
+        root.classList.add(`colors-${theme}`);
 
         // get list of logins
         logins = await Login.prototype.getAll(settings);
@@ -72,6 +71,7 @@ async function run() {
         helpers.handleError(e);
     }
 }
+
 
 function page(component) {
     return {


### PR DESCRIPTION
This PR implements #203. It adds an `Auto` theme mode that uses the `prefers-color-scheme: dark` media query to select light or dark theme. 

Replaces #271. Credit to @pixix4 - thank you 🙂