### PR TITLE
Fix otp in firefox v122-132

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1035,12 +1035,18 @@ async function parseFields(settings, login) {
         if (login.fields.otp.match(/^otpauth:\/\/.+/i)) {
             // attempt to parse otp data as URI
             try {
-                let url = new URL(login.fields.otp.toLowerCase());
-                let otpParts = url.pathname.split("/").filter((s) => s.trim());
+                // change otpauth:// to http:// to work around the fact
+                // that in older firefox versions there is a bug (fixed in
+                // 133) where the hostname is read as an empty string for
+                // urls that use a custom protocol like otpauth:// so the
+                // parsing behavior of such urls changes depending on
+                // browser version, while if we change it to http:// first
+                // then we always get the same result
+                let url = new URL(login.fields.otp.toLowerCase().replace("otpauth://", "http://"));
                 login.fields.otp = {
                     raw: login.fields.otp,
                     params: {
-                        type: otpParts[0] === "otp" ? "totp" : otpParts[0],
+                        type: url.host === "otp" ? "totp" : url.host,
                         secret: url.searchParams.get("secret").toUpperCase(),
                         algorithm: url.searchParams.get("algorithm") || "sha1",
                         digits: parseInt(url.searchParams.get("digits") || "6"),

--- a/src/background.js
+++ b/src/background.js
@@ -1035,9 +1035,8 @@ async function parseFields(settings, login) {
         if (login.fields.otp.match(/^otpauth:\/\/.+/i)) {
             // attempt to parse otp data as URI
             try {
-                // change otpauth:// to http:// to work around the fact
-                // that in older firefox versions there is a bug (fixed in
-                // 133) where the hostname is read as an empty string for
+                // change otpauth:// to http:// to work around a bug in firefox versions
+                // between 122 and 132 where the hostname is read as an empty string for
                 // urls that use a custom protocol like otpauth:// so the
                 // parsing behavior of such urls changes depending on
                 // browser version, while if we change it to http:// first


### PR DESCRIPTION
close https://github.com/browserpass/browserpass-extension/issues/340

see explanation in https://github.com/browserpass/browserpass-extension/issues/340#issuecomment-2547639403

tested by running `make firefox` and then load temporary addon in firefox, it resolves the issue for me
