### PR TITLE
Allow auth request to proceed when browserpass window is closed

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -172,7 +172,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
         }
     } else if (alarm.name === "clearAuthRequest") {
         if (currentAuthRequest !== null) {
-            resolveAuthRequest({ cancel: true }, currentAuthRequest.url);
+            resolveAuthRequest({ cancel: false }, currentAuthRequest.url);
         }
     }
 });


### PR DESCRIPTION
closes #370 will allow user to enter their own credentials for basic auth request when they close browserpass extension window. 