### PR TITLE
folder completion: preserve input rhs of cursor

### DIFF
--- a/src/popup/addEditInterface.js
+++ b/src/popup/addEditInterface.js
@@ -91,13 +91,7 @@ function AddEditInterface(settingsModel) {
                 case "Enter":
                     e.preventDefault();
                     if (e.target.classList.contains("directory")) {
-                        // replace search term with selected directory
-                        inputEl.value = `${addDirToLoginPath(
-                            loginObj.login,
-                            e.target.getAttribute("value")
-                        )}/`;
-                        this.state.setLogin(inputEl.value);
-                        inputEl.focus();
+                        clickDirectoryHandler.apply(this, [e]);
                     }
                     break;
                 case "Home":
@@ -143,9 +137,12 @@ function AddEditInterface(settingsModel) {
         function clickDirectoryHandler(e) {
             e.preventDefault();
             var inputEl = document.querySelector("input.filePath");
-
-            // replace search term with selected directory
-            inputEl.value = `${addDirToLoginPath(loginObj.login, e.target.getAttribute("value"))}/`;
+            var dir = e.target.getAttribute("value");
+            var val = inputEl.value;
+            var pos = inputEl.selectionStart;
+            var newLeft = addDirToLoginPath(val.slice(0, pos), dir) + "/";
+            inputEl.value = newLeft + val.slice(pos);
+            inputEl.selectionStart = inputEl.selectionEnd = newLeft.length;
             this.state.setLogin(inputEl.value);
             inputEl.focus();
         }
@@ -220,6 +217,19 @@ function AddEditInterface(settingsModel) {
                 length = login.login.length;
             }
             return `min-width: 65px; max-width: 442px; width: ${length * 8}px;`;
+        }
+
+        /**
+         * Update login
+         *
+         * @since 3.11.0
+         *
+         * @param {object} vnode
+         */
+        function updateLogin(vnode) {
+            const path = vnode.target.value;
+            const cursorPos = vnode.target.selectionStart;
+            this.setLogin(path, path.slice(0, cursorPos));
         }
 
         /**
@@ -325,11 +335,12 @@ function AddEditInterface(settingsModel) {
              * @since 3.8.0
              *
              * @param {string} path
+             * @param {string} pathPreceedingCursor
              */
-            setLogin: function (path) {
+            setLogin: function (path, pathPreceedingCursor) {
                 loginObj.login = path;
                 if (canTree) {
-                    storeDirs = storeTree.search(path);
+                    storeDirs = storeTree.search(pathPreceedingCursor ?? path);
                 } else {
                     storeDirs = [];
                 }
@@ -465,8 +476,10 @@ function AddEditInterface(settingsModel) {
                                 placeholder: "filename",
                                 value: loginObj.login,
                                 style: `${getPathWidth(loginObj)}`,
-                                oninput: m.withAttr("value", this.setLogin),
-                                onfocus: m.withAttr("value", this.setLogin),
+                                oninput: updateLogin.bind(this),
+                                onfocus: updateLogin.bind(this),
+                                onmouseup: updateLogin.bind(this),
+                                onkeyup: updateLogin.bind(this),
                                 onkeydown: pathKeyHandler.bind(vnode),
                             }),
                             m(`div.suffix${editing ? ".disabled" : ""}`, ".gpg"),


### PR DESCRIPTION
Suppose your password store has folders "personal" and "work".
Press "Add credentials" in the popup, in the file name enter "github.com" (will be automatically done by #383), then press Home and try to autocomplete "personal" folder.

Before: autocomplete wouldn't show up
After: autocomplete shows up based on what there is on the left side of the cursor. So you can type "p" and it will exclude "work" and keep showing "personal". Pressing Enter prepends folder name, without overwriting "github.com".