### PR TITLE
Add support for aria-label username fields

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -23,6 +23,11 @@
             "input[class=username i]",
             "input[class=email i]",
             "input[class=alias i]",
+            "input[aria-label=login i]",
+            "input[aria-label=user i]",
+            "input[aria-label=username i]",
+            "input[aria-label=email i]",
+            "input[aria-label=alias i]",
 
             "input[name*=login i]",
             "input[name*=user i]",


### PR DESCRIPTION
Here's an example of a login page that this PR adds support for: https://portal.hmc.edu
(No account needed to view the login page, just click Login in the top right.)

Here is the input field for the username, which doesn't match any of the existing patterns:

```html
<input id="identification" placeholder="Username" aria-label="Username" class="input placeholder-input ember-view ember-text-field">
```

However, `aria-label="Username"` seems pretty unambiguous to me, so I think we might as well match on it.