### PR TITLE
ensure addListener takes a synchronous callback

### DIFF
--- a/src/offscreen/offscreen.js
+++ b/src/offscreen/offscreen.js
@@ -3,7 +3,12 @@
 const clipboard = require("../helpers/clipboard");
 
 //----------------------------------- Function definitions ----------------------------------//
-chrome.runtime.onMessage.addListener(handleMessage);
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+    handleMessage(message, sender, sendResponse);
+
+    // allow async responses after this function returns
+    return true;
+});
 
 async function handleMessage(message, sender, sendResponse) {
     if (sender.id !== chrome.runtime.id) {
@@ -21,7 +26,7 @@ async function handleMessage(message, sender, sendResponse) {
     try {
         switch (message.type) {
             case "copy-data-to-clipboard":
-                clipboard.writeToClipboard(message.data);
+                await clipboard.writeToClipboard(message.data);
                 break;
             case "read-from-clipboard":
                 reply = clipboard.readFromClipboard();


### PR DESCRIPTION
Another potential improvement to help with #404 

As per https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sendresponse:

<img width="1534" height="998" alt="image" src="https://github.com/user-attachments/assets/9f06d5cb-d0d4-464c-a4a8-9e23bb2c10f5" />

I'm reusing the same pattern used in:

https://github.com/browserpass/browserpass-extension/blob/0138231cd1828726566eb3c9132aa179c72c4793/src/background.js#L61-L67