### PR TITLE
Use keyboard layout for popup shortcuts

### DIFF
--- a/src/popup/interface.js
+++ b/src/popup/interface.js
@@ -180,6 +180,11 @@ function renderMainView(ctl, params) {
                 onkeydown: (e) => {
                     e.preventDefault();
 
+                    if (e.ctrlKey && e.key.toLowerCase() === "a") {
+                        e.target.click();
+                        return;
+                    }
+
                     function goToElement(element) {
                         element.focus();
                         element.scrollIntoView();
@@ -206,10 +211,6 @@ function renderMainView(ctl, params) {
                             break;
                         case "Enter":
                             e.target.click();
-                        case "KeyA":
-                            if (e.ctrlKey) {
-                                e.target.click();
-                            }
                             break;
                         default:
                             break;
@@ -252,6 +253,36 @@ function search(searchQuery) {
 function keyHandler(e) {
     e.preventDefault();
     var login = e.target.classList.contains("login") ? e.target : e.target.closest(".login");
+
+    if (e.ctrlKey) {
+        switch (e.key.toLowerCase()) {
+            case "a":
+                document.querySelector(".part.add").click();
+                return;
+            case "c":
+                if (e.shiftKey || document.activeElement.classList.contains("copy-user")) {
+                    this.doAction("copyUsername");
+                } else {
+                    this.doAction("copyPassword");
+                }
+                return;
+            case "g": {
+                const event = e;
+                const target = this;
+                dialog.open(
+                    helpers.LAUNCH_URL_DEPRECATION_MESSAGE,
+                    function () {
+                        target.doAction(event.shiftKey ? "launchInNewTab" : "launch");
+                    },
+                    false
+                );
+                return;
+            }
+            case "o":
+                e.target.querySelector("div.action.details").click();
+                return;
+        }
+    }
 
     switch (e.code) {
         case "Tab":
@@ -302,38 +333,6 @@ function keyHandler(e) {
                 e.target.click();
             } else {
                 this.doAction("fill");
-            }
-            break;
-        case "KeyA":
-            if (e.ctrlKey) {
-                document.querySelector(".part.add").click();
-            }
-            break;
-        case "KeyC":
-            if (e.ctrlKey) {
-                if (e.shiftKey || document.activeElement.classList.contains("copy-user")) {
-                    this.doAction("copyUsername");
-                } else {
-                    this.doAction("copyPassword");
-                }
-            }
-            break;
-        case "KeyG":
-            if (e.ctrlKey) {
-                const event = e;
-                const target = this;
-                dialog.open(
-                    helpers.LAUNCH_URL_DEPRECATION_MESSAGE,
-                    function () {
-                        target.doAction(event.shiftKey ? "launchInNewTab" : "launch");
-                    },
-                    false
-                );
-            }
-            break;
-        case "KeyO":
-            if (e.ctrlKey) {
-                e.target.querySelector("div.action.details").click();
             }
             break;
         case "Home": {

--- a/src/popup/searchinterface.js
+++ b/src/popup/searchinterface.js
@@ -101,6 +101,36 @@ function view(ctl, params) {
                     self.popup.search(e.target.value);
                 },
                 onkeydown: function (e) {
+                    if (e.ctrlKey && e.target.selectionStart == e.target.selectionEnd) {
+                        switch (e.key.toLowerCase()) {
+                            case "c":
+                                e.preventDefault();
+                                self.popup.results[0].doAction(
+                                    e.shiftKey ? "copyUsername" : "copyPassword"
+                                );
+                                return;
+                            case "g": {
+                                e.preventDefault();
+                                const event = e;
+                                const target = self.popup.results[0];
+                                dialog.open(
+                                    helpers.LAUNCH_URL_DEPRECATION_MESSAGE,
+                                    function () {
+                                        target.doAction(
+                                            event.shiftKey ? "launchInNewTab" : "launch"
+                                        );
+                                    },
+                                    false
+                                );
+                                return;
+                            }
+                            case "o":
+                                e.preventDefault();
+                                self.popup.results[0].doAction("getDetails");
+                                return;
+                        }
+                    }
+
                     switch (e.code) {
                         case "Backspace":
                             if (self.popup.currentDomainOnly) {
@@ -114,36 +144,6 @@ function view(ctl, params) {
                                     self.popup.currentDomainOnly = false;
                                     self.popup.search(e.target.value);
                                 }
-                            }
-                            break;
-                        case "KeyC":
-                            if (e.ctrlKey && e.target.selectionStart == e.target.selectionEnd) {
-                                e.preventDefault();
-                                self.popup.results[0].doAction(
-                                    e.shiftKey ? "copyUsername" : "copyPassword"
-                                );
-                            }
-                            break;
-                        case "KeyG":
-                            if (e.ctrlKey && e.target.selectionStart == e.target.selectionEnd) {
-                                e.preventDefault();
-                                const event = e;
-                                const target = self.popup.results[0];
-                                dialog.open(
-                                    helpers.LAUNCH_URL_DEPRECATION_MESSAGE,
-                                    function () {
-                                        target.doAction(
-                                            event.shiftKey ? "launchInNewTab" : "launch"
-                                        );
-                                    },
-                                    false
-                                );
-                            }
-                            break;
-                        case "KeyO":
-                            if (e.ctrlKey && e.target.selectionStart == e.target.selectionEnd) {
-                                e.preventDefault();
-                                self.popup.results[0].doAction("getDetails");
                             }
                             break;
                         case "End": {


### PR DESCRIPTION
This changes popup letter shortcuts to use `KeyboardEvent.key` instead of `KeyboardEvent.code`.

`code` refers to the physical key, so shortcuts like Ctrl+C break for custom keyboard layouts. `key` reflects the active keyboard layout, which matches user expectations for Ctrl+C,
Ctrl+G, Ctrl+O, and Ctrl+A.

Navigation keys still use `code`.

Tested locally with a custom keyboard layout where the physical key and produced character differ.

Fixes #359 .
