### PR TITLE
fix: generate RFC-compliant TOTP codes

### DIFF
--- a/src/helpers/base.js
+++ b/src/helpers/base.js
@@ -366,6 +366,9 @@ function makeTOTP(params) {
         crypto: {
             createHmac: (a, k) => hash.hmac(hash[a], k),
         },
+        // HMAC handles key padding internally. Avoid otplib's non-standard
+        // repetition/truncation of secrets that do not match the hash length.
+        createHmacSecret: (secret, options) => Buffer.from(secret, options.encoding),
         algorithm: params.algorithm,
         digits: params.digits,
         step: params.period,

--- a/src/helpers/base.test.js
+++ b/src/helpers/base.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const assert = require("assert");
+const { makeTOTP } = require("./base");
+
+const originalDateNow = Date.now;
+
+try {
+    Date.now = () => 59000;
+
+    const shortSecret = "GEZDGNBV"; // Base32 for the five-byte ASCII string "12345".
+
+    assert.strictEqual(
+        makeTOTP({ algorithm: "sha1", digits: 8, period: 30, secret: shortSecret }),
+        "56662488"
+    );
+    assert.strictEqual(
+        makeTOTP({ algorithm: "sha256", digits: 8, period: 30, secret: shortSecret }),
+        "51639141"
+    );
+    assert.strictEqual(
+        makeTOTP({ algorithm: "sha512", digits: 8, period: 30, secret: shortSecret }),
+        "96422252"
+    );
+
+    assert.strictEqual(
+        makeTOTP({
+            algorithm: "sha1",
+            digits: 8,
+            period: 30,
+            secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+        }),
+        "94287082"
+    );
+} finally {
+    Date.now = originalDateNow;
+}

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,9 @@
             "email": "steve@erayd.net"
         }
     ],
+    "scripts": {
+        "test": "node helpers/base.test.js"
+    },
     "dependencies": {
         "@browserpass/url": "^1.2.0",
         "chrome-extension-async": "^3.4.1",


### PR DESCRIPTION
Fixes #358

`otplib` 11 transforms TOTP secrets to the digest length before HMAC. For short seeds that repeats the decoded bytes, which produces a different key and therefore a different OTP than other RFC-compatible implementations.

This overrides the library's documented `createHmacSecret` hook so HMAC receives the decoded secret bytes unchanged and performs its normal RFC 2104 key handling.

I also added regression vectors for short SHA-1, SHA-256, and SHA-512 secrets, plus the standard 20-byte SHA-1 vector.

Verification:

- `yarn test`
- `prettier --check package.json helpers/base.test.js`
- Browserify compilation of `background.js`

